### PR TITLE
feat: add packed attention with column-wise packing and inverse-free LayerNorm

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -311,3 +311,8 @@ Apache License 2.0
 - [Homomorphic Encryption for Arithmetic of Approximate Numbers](https://eprint.iacr.org/2016/421) — Cheon et al. (CKKS)
 - [Bootstrapping for Approximate Homomorphic Encryption](https://eprint.iacr.org/2018/153) — Cheon et al.
 - [Faster Homomorphic Linear Transformations in HElib](https://eprint.iacr.org/2018/244) — Halevi & Shoup (BSGS)
+- [GAZELLE: A Low Latency Framework for Secure Neural Network Inference](https://www.usenix.org/conference/usenixsecurity18/presentation/juvekar) — Juvekar et al. (합성곱)
+- [PP-STAT: An Efficient Privacy-Preserving Statistical Analysis Framework using Homomorphic Encryption](https://doi.org/10.1145/3583780) — Choi (암호화 통계)
+- [STIP: Efficient and Secure Non-Interactive Transformer Inference via Compact Packing](https://doi.org/10.1145/3696410.3714779) — Wang et al. (패킹 어텐션)
+- [Efficient Bootstrapping for Approximate Homomorphic Encryption](https://eprint.iacr.org/2020/1203) — Bossuat et al. (Double-Hoisting)
+- [On the Number of Nonscalar Multiplications Necessary to Evaluate Polynomials](https://doi.org/10.1137/0202007) — Paterson & Stockmeyer (다항식 평가)

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ pip install -e .
 | `nn.AvgPool2d` | `EncryptedAvgPool2d` | Rotation-based |
 | `nn.BatchNorm` | Folded | Merged into prev layer |
 | `nn.LayerNorm` | `EncryptedLayerNorm` | Polynomial approx |
-| `nn.Attention` | `EncryptedApproxAttention` | seq_len=1 |
+| `nn.Attention` | `EncryptedApproxAttention` | seq_len=1 or packed/list seq_len <= 8 |
 
 <details>
 <summary><strong>Full layer support table</strong></summary>
@@ -171,7 +171,7 @@ pip install -e .
 | `nn.Sequential` | `EncryptedSequential` | Full support |
 | `nn.Dropout` | `EncryptedDropout` | No-op during inference |
 | `nn.LayerNorm` | `EncryptedLayerNorm` | Pure HE polynomial approximation |
-| `nn.MultiheadAttention` | `EncryptedApproxAttention` | Polynomial softmax (seq_len=1) |
+| `nn.MultiheadAttention` | `EncryptedApproxAttention` | Taylor softmax (seq_len=1) or Power-Softmax (packed/list seq_len <= 8) |
 
 </details>
 
@@ -309,3 +309,8 @@ Apache License 2.0
 - [Homomorphic Encryption for Arithmetic of Approximate Numbers](https://eprint.iacr.org/2016/421) — Cheon et al. (CKKS)
 - [Bootstrapping for Approximate Homomorphic Encryption](https://eprint.iacr.org/2018/153) — Cheon et al.
 - [Faster Homomorphic Linear Transformations in HElib](https://eprint.iacr.org/2018/244) — Halevi & Shoup (BSGS)
+- [GAZELLE: A Low Latency Framework for Secure Neural Network Inference](https://www.usenix.org/conference/usenixsecurity18/presentation/juvekar) — Juvekar et al. (Convolution)
+- [PP-STAT: An Efficient Privacy-Preserving Statistical Analysis Framework using Homomorphic Encryption](https://doi.org/10.1145/3583780) — Choi (Encrypted Statistics)
+- [STIP: Efficient and Secure Non-Interactive Transformer Inference via Compact Packing](https://doi.org/10.1145/3696410.3714779) — Wang et al. (Packed Attention)
+- [Efficient Bootstrapping for Approximate Homomorphic Encryption](https://eprint.iacr.org/2020/1203) — Bossuat et al. (Double-Hoisting)
+- [On the Number of Nonscalar Multiplications Necessary to Evaluate Polynomials](https://doi.org/10.1137/0202007) — Paterson & Stockmeyer (Polynomial Evaluation)

--- a/cukks/analysis/__init__.py
+++ b/cukks/analysis/__init__.py
@@ -1,0 +1,11 @@
+"""
+Graph analysis utilities for CuKKS model conversion.
+
+This module provides torch.fx-based analysis passes that inspect
+PyTorch model graphs to determine which layers qualify for
+optimized encrypted conversion (e.g., inverse-free LayerNorm).
+"""
+
+from .inverse_free_detect import detect_inverse_free_layernorms
+
+__all__ = ["detect_inverse_free_layernorms"]

--- a/cukks/analysis/inverse_free_detect.py
+++ b/cukks/analysis/inverse_free_detect.py
@@ -1,0 +1,196 @@
+"""
+Detect LayerNorm modules eligible for inverse-free conversion.
+
+Uses torch.fx symbolic tracing to build a dataflow graph of the model,
+then walks paths between consecutive LayerNorm nodes. A LayerNorm qualifies
+for inverse-free conversion when every operation on the path to the next
+LayerNorm is either:
+  - nn.Linear (weight multiply + bias)
+  - nn.ReLU  (homogeneous: ReLU(σx) = σ·ReLU(x))
+  - nn.Dropout / nn.Identity (no-ops at eval time)
+  - addition (residual connections are allowed between the two LNs only
+    if both branches carry the same σ factor — conservatively, we reject
+    residual add nodes unless they come from the same inverse-free LN
+    subtree)
+
+If tracing fails (dynamic control flow, unsupported ops), returns an empty
+set and logs a warning so the converter falls back to standard LayerNorm.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+
+import torch
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+# Operation types that preserve a multiplicative σ scaling factor.
+# These are the ONLY module types allowed on the path between an
+# inverse-free LN and the standard LN that cancels σ.
+_HOMOGENEOUS_MODULE_TYPES: Tuple[type, ...] = (
+    nn.Linear,
+    nn.ReLU,
+    nn.Dropout,
+    nn.Identity,
+)
+
+
+def detect_inverse_free_layernorms(model: nn.Module) -> FrozenSet[str]:
+    """Return the fully-qualified names of LayerNorm modules that can use
+    inverse-free conversion.
+
+    The analysis is conservative: if tracing fails or the graph contains
+    ambiguous paths, no modules are marked.
+
+    Args:
+        model: A PyTorch model in eval mode.
+
+    Returns:
+        Frozen set of module name strings (e.g. ``{"encoder.norm1"}``).
+        Empty if tracing fails or no eligible pairs are found.
+    """
+    try:
+        import torch.fx as fx
+
+        traced = fx.symbolic_trace(model)
+    except Exception as exc:
+        logger.warning(
+            "torch.fx tracing failed (%s); inverse-free LayerNorm "
+            "detection skipped. All LayerNorms will use standard conversion.",
+            exc,
+        )
+        return frozenset()
+
+    graph = traced.graph
+
+    # ---------------------------------------------------------------
+    # 1. Build a map: node → module-name for call_module nodes
+    # ---------------------------------------------------------------
+    node_to_name: Dict[fx.Node, str] = {}
+    name_to_node: Dict[str, fx.Node] = {}
+    for node in graph.nodes:
+        if node.op == "call_module":
+            node_to_name[node] = node.target  # type: ignore[assignment]
+            name_to_node[node.target] = node  # type: ignore[index]
+
+    # ---------------------------------------------------------------
+    # 2. Identify all LayerNorm nodes
+    # ---------------------------------------------------------------
+    ln_names: List[str] = []
+    for node in graph.nodes:
+        if node.op == "call_module":
+            target_name: str = node.target  # type: ignore[assignment]
+            submod = _get_submodule(model, target_name)
+            if isinstance(submod, nn.LayerNorm):
+                ln_names.append(target_name)
+
+    if len(ln_names) < 2:
+        return frozenset()
+
+    # ---------------------------------------------------------------
+    # 3. For each LN, find all downstream LN nodes reachable through
+    #    only homogeneous ops and check eligibility.
+    # ---------------------------------------------------------------
+    eligible: Set[str] = set()
+
+    for src_name in ln_names:
+        src_node = name_to_node.get(src_name)
+        if src_node is None:
+            continue
+
+        # BFS/DFS from src_node's users, looking for the next LN.
+        reached_lns = _find_next_layernorms_through_homogeneous(
+            src_node, model, ln_names,
+        )
+        if reached_lns:
+            eligible.add(src_name)
+
+    return frozenset(eligible)
+
+
+def _find_next_layernorms_through_homogeneous(
+    src_node: "torch.fx.Node",
+    model: nn.Module,
+    all_ln_names: List[str],
+) -> List[str]:
+    """BFS from *src_node* following only homogeneous-safe edges.
+
+    Returns the names of LayerNorm modules reachable through paths where
+    every intermediate call_module is a homogeneous type.
+    """
+    ln_name_set = set(all_ln_names)
+    visited: Set["torch.fx.Node"] = set()
+    queue: List["torch.fx.Node"] = list(src_node.users.keys())
+    reached: List[str] = []
+
+    while queue:
+        node = queue.pop(0)
+        if node in visited:
+            continue
+        visited.add(node)
+
+        if node.op == "call_module":
+            target: str = node.target  # type: ignore[assignment]
+
+            # Reached another LayerNorm → this is the "cancelling" LN.
+            if target in ln_name_set:
+                reached.append(target)
+                continue  # Don't traverse past the cancelling LN.
+
+            # Check if the intermediate module is homogeneous-safe.
+            submod = _get_submodule(model, target)
+            if not isinstance(submod, _HOMOGENEOUS_MODULE_TYPES):
+                continue  # Path is broken — stop exploring this branch.
+
+            # Safe module: continue traversing its users.
+            queue.extend(node.users.keys())
+
+        elif node.op == "call_function":
+            fn = node.target
+            # Allow element-wise add (residual connections).
+            if fn in (torch.add, _operator_add()):
+                queue.extend(node.users.keys())
+            # Allow functional ReLU variants.
+            elif fn in (torch.relu, torch.nn.functional.relu):
+                queue.extend(node.users.keys())
+            else:
+                continue  # Non-homogeneous function — stop.
+
+        elif node.op == "call_method":
+            # Allow .add() method and similar safe operations
+            if node.target in ("add", "add_"):
+                queue.extend(node.users.keys())
+            else:
+                continue
+
+        elif node.op in ("placeholder", "get_attr"):
+            # These don't represent computation; skip.
+            queue.extend(node.users.keys())
+
+        elif node.op == "output":
+            # Reached the output without hitting another LN — this path
+            # doesn't have a cancelling LN, so it's not eligible.
+            continue
+
+        else:
+            # Unknown op type — be conservative, stop.
+            continue
+
+    return reached
+
+
+def _get_submodule(model: nn.Module, target: str) -> Optional[nn.Module]:
+    """Safely retrieve a submodule by dotted name."""
+    try:
+        return model.get_submodule(target)
+    except AttributeError:
+        return None
+
+
+def _operator_add() -> object:
+    """Return operator.add without importing at module level."""
+    import operator
+    return operator.add

--- a/cukks/batching/__init__.py
+++ b/cukks/batching/__init__.py
@@ -8,6 +8,17 @@ Classes:
     SlotPacker: Pack/unpack multiple samples into CKKS slots.
 """
 
+from .layout import PackingLayout, TokenBlockPacker
 from .packing import SlotPacker
+from .amcp import AMCPacker
+from .dhp import DHPacker
+from .rihp import RIHPacker
 
-__all__ = ["SlotPacker"]
+__all__ = [
+    "SlotPacker",
+    "PackingLayout",
+    "TokenBlockPacker",
+    "RIHPacker",
+    "AMCPacker",
+    "DHPacker",
+]

--- a/cukks/batching/amcp.py
+++ b/cukks/batching/amcp.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from cukks.tensor import EncryptedTensor
+
+if TYPE_CHECKING:
+    from cukks.context import CKKSInferenceContext
+
+
+class AMCPacker:
+    def __init__(self, num_heads: int, seq_len: int, batch_size: int, total_slots: int) -> None:
+        if num_heads <= 0:
+            raise ValueError(f"num_heads must be positive, got {num_heads}")
+        if seq_len <= 0:
+            raise ValueError(f"seq_len must be positive, got {seq_len}")
+        if batch_size <= 0:
+            raise ValueError(f"batch_size must be positive, got {batch_size}")
+        if total_slots <= 0:
+            raise ValueError(f"total_slots must be positive, got {total_slots}")
+
+        self.num_heads = num_heads
+        self.seq_len = seq_len
+        self.batch_size = batch_size
+        self.total_slots = total_slots
+        self.k = self.compute_packing_factor(
+            num_heads=num_heads,
+            seq_len=seq_len,
+            batch_size=batch_size,
+            total_slots=total_slots,
+        )
+        self.stride = total_slots // seq_len
+        self.width = self.k * batch_size
+
+    @staticmethod
+    def compute_packing_factor(num_heads: int, seq_len: int, batch_size: int, total_slots: int) -> int:
+        divisors: list[int] = []
+        candidate = 1
+        while candidate * candidate <= num_heads:
+            if num_heads % candidate == 0:
+                divisors.append(candidate)
+                pair = num_heads // candidate
+                if pair != candidate:
+                    divisors.append(pair)
+            candidate += 1
+
+        valid = [
+            factor
+            for factor in divisors
+            if factor * batch_size * seq_len <= total_slots
+        ]
+        if not valid:
+            raise ValueError(
+                "No valid AMCP packing factor: requires k * batch_size * seq_len <= total_slots "
+                f"for some k dividing num_heads={num_heads}; got seq_len={seq_len}, "
+                f"batch_size={batch_size}, total_slots={total_slots}"
+            )
+        return max(valid)
+
+    def build_masks(self) -> tuple[list[float], list[float]]:
+        t = self.batch_size
+        phi = self.stride
+        width = self.width
+
+        u_block = [1.0] * (width - t) + [0.0] * t + [0.0] * (phi - width)
+        v_block = [0.0] * t + [1.0] * (width - t) + [0.0] * (phi - width)
+
+        u_mask = u_block * self.seq_len
+        v_mask = v_block * self.seq_len
+        return u_mask, v_mask
+
+    def group_wise_rotation(
+        self,
+        ciphertext: EncryptedTensor,
+        ctx: CKKSInferenceContext,
+    ) -> list[EncryptedTensor]:
+        u_mask, v_mask = self.build_masks()
+        u_enc = ctx.encrypt(torch.tensor(u_mask, dtype=torch.float64))
+        v_enc = ctx.encrypt(torch.tensor(v_mask, dtype=torch.float64))
+
+        aligned = [ciphertext]
+        for _ in range(self.k - 1):
+            current = aligned[-1]
+            left = current.rotate(self.batch_size)
+            right = current.rotate(-(self.width - self.batch_size))
+            next_state = left.mul(u_enc).add(right.mul(v_enc))
+            aligned.append(next_state)
+        return aligned
+
+    def scale_rotation(self, logical_step: int) -> int:
+        return logical_step * self.stride

--- a/cukks/batching/dhp.py
+++ b/cukks/batching/dhp.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import torch
+
+from cukks.tensor import EncryptedTensor
+
+
+class DHPacker:
+    def __init__(self, num_heads: int) -> None:
+        if num_heads <= 0:
+            raise ValueError(f"num_heads must be positive, got {num_heads}")
+        if num_heads % 2 != 0:
+            raise ValueError(f"num_heads must be even for DHP, got {num_heads}")
+        self.num_heads = num_heads
+        self.num_pairs = num_heads // 2
+
+    @staticmethod
+    def precode_weights(w_h: torch.Tensor, w_h1: torch.Tensor) -> torch.Tensor:
+        if w_h.shape != w_h1.shape:
+            raise ValueError(
+                "w_h and w_h1 must have same shape, "
+                f"got {tuple(w_h.shape)} and {tuple(w_h1.shape)}"
+            )
+        w_h_complex = w_h.to(dtype=torch.complex128)
+        w_h1_complex = w_h1.to(dtype=torch.complex128)
+        return w_h_complex + 1j * w_h1_complex
+
+    def parallel_projection(
+        self,
+        inputs: list[EncryptedTensor],
+        precoded_weights: list[list[float | complex]],
+    ) -> list[EncryptedTensor]:
+        if len(inputs) != len(precoded_weights):
+            raise ValueError(
+                "inputs and precoded_weights must have same length, "
+                f"got {len(inputs)} and {len(precoded_weights)}"
+            )
+        if not inputs:
+            return []
+        if not precoded_weights[0]:
+            return []
+
+        out_dim = len(precoded_weights[0])
+        for row_idx, row in enumerate(precoded_weights):
+            if len(row) != out_dim:
+                raise ValueError(
+                    "all rows in precoded_weights must have same length, "
+                    f"row 0 has {out_dim} and row {row_idx} has {len(row)}"
+                )
+
+        packed_outputs: list[EncryptedTensor] = []
+        for col in range(out_dim):
+            first_weight = complex(precoded_weights[0][col])
+            acc = inputs[0].mul(first_weight.real)
+            if first_weight.imag != 0.0:
+                acc = acc.add(inputs[0].mul(first_weight.imag).mul_by_i())
+
+            for row in range(1, len(inputs)):
+                weight = complex(precoded_weights[row][col])
+                term = inputs[row].mul(weight.real)
+                if weight.imag != 0.0:
+                    term = term.add(inputs[row].mul(weight.imag).mul_by_i())
+                acc = acc.add(term)
+            packed_outputs.append(acc)
+        return packed_outputs
+
+    def unpack_heads(
+        self,
+        packed: list[EncryptedTensor],
+    ) -> tuple[list[EncryptedTensor], list[EncryptedTensor]]:
+        head_h = [col.extract_real() for col in packed]
+        head_h1 = [col.extract_imag() for col in packed]
+        return head_h, head_h1
+
+    def repack_after_attention(
+        self,
+        att_h: list[EncryptedTensor],
+        att_h1: list[EncryptedTensor],
+    ) -> list[EncryptedTensor]:
+        if len(att_h) != len(att_h1):
+            raise ValueError(
+                "att_h and att_h1 must have same length, "
+                f"got {len(att_h)} and {len(att_h1)}"
+            )
+        repacked: list[EncryptedTensor] = []
+        for col_h, col_h1 in zip(att_h, att_h1):
+            repacked.append(col_h.add(col_h1.mul_by_i()))
+        return repacked
+
+    def extract_final(self, accumulated: EncryptedTensor) -> EncryptedTensor:
+        return accumulated.extract_real()

--- a/cukks/batching/layout.py
+++ b/cukks/batching/layout.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import torch
+
+
+@dataclass(frozen=True)
+class PackingLayout:
+    seq_len: int
+    d_model: int
+    num_heads: int
+    block_size: int
+    complex_packing: str = "real_only"
+
+    def __post_init__(self) -> None:
+        if self.seq_len <= 0:
+            raise ValueError(f"seq_len must be positive, got {self.seq_len}")
+        if self.d_model <= 0:
+            raise ValueError(f"d_model must be positive, got {self.d_model}")
+        if self.num_heads <= 0:
+            raise ValueError(f"num_heads must be positive, got {self.num_heads}")
+        if self.d_model % self.num_heads != 0:
+            raise ValueError(
+                f"d_model ({self.d_model}) must be divisible by num_heads ({self.num_heads})"
+            )
+        if self.block_size < self.d_model:
+            raise ValueError(
+                f"block_size ({self.block_size}) must be >= d_model ({self.d_model})"
+            )
+        if self.complex_packing not in {"real_only", "rihp", "dhp"}:
+            raise ValueError(
+                "complex_packing must be 'real_only', 'rihp', or 'dhp', "
+                f"got {self.complex_packing!r}"
+            )
+
+    @property
+    def d_head(self) -> int:
+        return self.d_model // self.num_heads
+
+    @property
+    def total_slots_needed(self) -> int:
+        return self.seq_len * self.block_size
+
+    def token_offset(self, offset: int) -> int:
+        return offset * self.block_size
+
+    def head_range(self, head_idx: int) -> tuple[int, int]:
+        if head_idx < 0 or head_idx >= self.num_heads:
+            raise ValueError(f"head_idx must be in [0, {self.num_heads}), got {head_idx}")
+        start = head_idx * self.d_head
+        return (start, start + self.d_head)
+
+
+@dataclass
+class TokenBlockPacker:
+    layout: PackingLayout
+    total_slots: int
+    _cached_masks: list[list[float]] | None = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if self.total_slots < self.layout.total_slots_needed:
+            raise ValueError(
+                f"total_slots ({self.total_slots}) must be >= "
+                f"layout.total_slots_needed ({self.layout.total_slots_needed})"
+            )
+
+    def pack(self, x: torch.Tensor) -> torch.Tensor:
+        if self.layout.complex_packing != "real_only":
+            raise NotImplementedError(
+                f"TokenBlockPacker does not yet implement {self.layout.complex_packing} packing"
+            )
+        tensor = x.detach().to(dtype=torch.float64, device="cpu")
+        expected_shape = (self.layout.seq_len, self.layout.d_model)
+        if tuple(tensor.shape) != expected_shape:
+            raise ValueError(f"Expected tensor shape {expected_shape}, got {tuple(tensor.shape)}")
+
+        packed = torch.zeros(self.total_slots, dtype=torch.float64)
+        for token_idx in range(self.layout.seq_len):
+            start = token_idx * self.layout.block_size
+            end = start + self.layout.d_model
+            packed[start:end] = tensor[token_idx]
+        return packed
+
+    def unpack(self, packed: torch.Tensor) -> torch.Tensor:
+        flat = packed.detach().to(dtype=torch.float64, device="cpu").reshape(-1)
+        if flat.numel() < self.total_slots:
+            raise ValueError(
+                f"Packed tensor has {flat.numel()} values, expected at least {self.total_slots}"
+            )
+        unpacked = torch.zeros((self.layout.seq_len, self.layout.d_model), dtype=torch.float64)
+        for token_idx in range(self.layout.seq_len):
+            start = token_idx * self.layout.block_size
+            end = start + self.layout.d_model
+            unpacked[token_idx] = flat[start:end]
+        return unpacked
+
+    def head_mask(self, head_idx: int) -> list[float]:
+        head_start, head_end = self.layout.head_range(head_idx)
+        mask = [0.0] * self.total_slots
+        for token_idx in range(self.layout.seq_len):
+            base = token_idx * self.layout.block_size
+            for slot_idx in range(base + head_start, base + head_end):
+                mask[slot_idx] = 1.0
+        return mask
+
+    def all_head_masks(self) -> list[list[float]]:
+        if self._cached_masks is None:
+            self._cached_masks = [self.head_mask(head_idx) for head_idx in range(self.layout.num_heads)]
+        return self._cached_masks

--- a/cukks/batching/rihp.py
+++ b/cukks/batching/rihp.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from cukks.tensor import EncryptedTensor
+
+
+class RIHPacker:
+    def __init__(self, seq_len: int) -> None:
+        if seq_len <= 0:
+            raise ValueError(f"seq_len must be positive, got {seq_len}")
+        if seq_len % 2 != 0:
+            raise ValueError(f"seq_len must be even for RIHP, got {seq_len}")
+        self.seq_len = seq_len
+        self.half_seq_len = seq_len // 2
+
+    def pack_hybrid(self, keys: list[EncryptedTensor]) -> list[EncryptedTensor]:
+        packed: list[EncryptedTensor] = []
+        for key_col in keys:
+            rotated = key_col.rotate(self.half_seq_len)
+            packed.append(key_col.add(rotated.mul_by_i()))
+        return packed
+
+    def halved_ccmm(
+        self,
+        queries: list[EncryptedTensor],
+        keys_hybrid: list[EncryptedTensor],
+    ) -> list[EncryptedTensor]:
+        if len(queries) != len(keys_hybrid):
+            raise ValueError(
+                "queries and keys_hybrid must have same length, "
+                f"got {len(queries)} and {len(keys_hybrid)}"
+            )
+        if not queries:
+            return []
+
+        packed_diagonals: list[EncryptedTensor] = []
+        for rotation in range(self.half_seq_len):
+            acc = queries[0].mul(keys_hybrid[0].rotate(rotation)).rescale()
+            for col in range(1, len(queries)):
+                term = queries[col].mul(keys_hybrid[col].rotate(rotation)).rescale()
+                acc = acc.add(term)
+            packed_diagonals.append(acc)
+        return packed_diagonals
+
+    def unpack_diagonals(self, hybrid_results: list[EncryptedTensor]) -> list[EncryptedTensor]:
+        if len(hybrid_results) != self.half_seq_len:
+            raise ValueError(
+                "hybrid_results must have length seq_len/2, "
+                f"got {len(hybrid_results)} for seq_len={self.seq_len}"
+            )
+
+        real_diagonals: list[EncryptedTensor] = []
+        imag_diagonals: list[EncryptedTensor] = []
+        for hybrid in hybrid_results:
+            real_diag = hybrid.add(hybrid.conjugate()).mul(0.5)
+            imag_diag = hybrid.extract_imag()
+            real_diagonals.append(real_diag)
+            imag_diagonals.append(imag_diag)
+        return real_diagonals + imag_diagonals

--- a/cukks/context.py
+++ b/cukks/context.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from .tensor import EncryptedTensor
 
 from .batching.packing import SlotPacker
+from .batching import PackingLayout, TokenBlockPacker
 
 CKKSConfig = None  # type: ignore
 CKKSContext = None  # type: ignore
@@ -111,11 +112,13 @@ class InferenceConfig:
         **kwargs: Any,
     ) -> "InferenceConfig":
         enable_gpu = kwargs.pop("enable_gpu", False)
+        attention_normalization_mode = kwargs.pop("attention_normalization_mode", "power_softmax")
         depth = _estimate_model_depth(
             model,
             activation_degree=activation_degree,
             use_square_activation=use_square_activation,
             enable_gpu=enable_gpu,
+            attention_normalization_mode=attention_normalization_mode,
         )
         return cls.for_depth(depth, **kwargs)
 
@@ -125,6 +128,7 @@ def _estimate_model_depth(
     activation_degree: int = 4,
     use_square_activation: bool = False,
     enable_gpu: bool = False,
+    attention_normalization_mode: str = "power_softmax",
 ) -> int:
     depth = 0
     if use_square_activation:
@@ -147,6 +151,8 @@ def _estimate_model_depth(
             torch.nn.Sigmoid, torch.nn.Tanh,
         )):
             depth += poly_depth
+        elif isinstance(module, torch.nn.MultiheadAttention):
+            depth += 9 if attention_normalization_mode == "gaussian" else 10
     return max(1, depth)
 
 
@@ -173,6 +179,9 @@ def _get_model_dimensions(model: torch.nn.Module, input_shape: Optional[Tuple[in
         elif isinstance(module, torch.nn.Linear):
             dims.append(module.in_features)
             dims.append(module.out_features)
+        elif isinstance(module, torch.nn.MultiheadAttention):
+            dims.append(module.embed_dim)
+            dims.append(module.embed_dim * 8)
         elif isinstance(module, torch.nn.Conv2d):
             has_conv = True
             kh, kw = (module.kernel_size, module.kernel_size) if isinstance(module.kernel_size, int) else module.kernel_size
@@ -332,7 +341,13 @@ class CKKSInferenceContext:
         cnn_config: Optional[Dict[str, Any]] = None,
         enable_gpu: bool = True,
         batch_size: int = 1,
+        architecture: str = "default",
     ):
+        if architecture not in {"default", "stip"}:
+            raise ValueError(
+                "architecture must be 'default' or 'stip', "
+                f"got {architecture!r}"
+            )
         if cnn_config is not None and config is None:
             config = InferenceConfig(mult_depth=6, security_level=None)
         
@@ -344,6 +359,7 @@ class CKKSInferenceContext:
         self._cnn_config = cnn_config
         self._enable_gpu = enable_gpu
         self._batch_size = batch_size
+        self._architecture = architecture
         
         _resolved_max_dim = max_rotation_dim
         if rotations is None:
@@ -680,6 +696,62 @@ class CKKSInferenceContext:
             samples = [s.to(self.device) for s in samples]
         
         return samples
+
+    def encrypt_sequence(
+        self,
+        tensor: torch.Tensor,
+        *,
+        num_heads: int,
+        block_size: Optional[int] = None,
+    ) -> "EncryptedTensor":
+        from .tensor import EncryptedTensor
+
+        self._ensure_initialized()
+
+        if tensor.ndim != 2:
+            raise ValueError(f"Expected 2D tensor (seq_len, d_model), got shape {tuple(tensor.shape)}")
+
+        seq_len, d_model = tensor.shape
+        resolved_block_size = int(block_size) if block_size is not None else int(d_model)
+        layout = PackingLayout(
+            seq_len=int(seq_len),
+            d_model=int(d_model),
+            num_heads=int(num_heads),
+            block_size=resolved_block_size,
+        )
+        if layout.total_slots_needed > self.num_slots:
+            raise ValueError(
+                f"Sequence requires {layout.total_slots_needed} slots but context has {self.num_slots}"
+            )
+
+        packer = TokenBlockPacker(layout, self.num_slots)
+        packed = packer.pack(tensor)
+        cipher = self._ctx.encrypt(packed.to(dtype=torch.float64, device="cpu"))
+        enc_tensor = EncryptedTensor(cipher, (layout.seq_len, layout.d_model), self)
+        enc_tensor._packing_layout = layout
+        enc_tensor._stip_layout_fresh = True
+        return enc_tensor
+
+    def decrypt_sequence(self, encrypted: "EncryptedTensor") -> torch.Tensor:
+        self._ensure_initialized()
+
+        layout = getattr(encrypted, "_packing_layout", None)
+        if layout is None:
+            raise ValueError("EncryptedTensor has no STIP packing layout")
+        if not getattr(encrypted, "_stip_layout_fresh", False):
+            raise ValueError("EncryptedTensor does not have fresh STIP sequence-layout provenance")
+        if encrypted.shape != (layout.seq_len, layout.d_model):
+            raise ValueError(
+                "EncryptedTensor shape does not match STIP packing layout. "
+                f"Got tensor shape {encrypted.shape} and layout {(layout.seq_len, layout.d_model)}."
+            )
+
+        full_result = self._ctx.decrypt(encrypted._cipher, shape=None)
+        packer = TokenBlockPacker(layout, self.num_slots)
+        recovered = packer.unpack(full_result)
+        if self.device != "cpu":
+            recovered = recovered.to(self.device)
+        return recovered.to(torch.float32)
     
     def encrypt_cnn_input(
         self,
@@ -730,6 +802,8 @@ class CKKSInferenceContext:
         activation_degree: int = 4,
         use_square_activation: bool = False,
         batch_size: int = 1,
+        attention_normalization_mode: str = "power_softmax",
+        architecture: str = "default",
         **kwargs: Any,
     ) -> "CKKSInferenceContext":
         enable_bootstrap = kwargs.pop("enable_bootstrap", False)
@@ -743,6 +817,7 @@ class CKKSInferenceContext:
             activation_degree=activation_degree,
             use_square_activation=use_square_activation,
             enable_gpu=kwargs.get("enable_gpu", False),
+            attention_normalization_mode=attention_normalization_mode,
             enable_bootstrap=enable_bootstrap,
             level_budget=level_budget,
             scale_bits=scale_bits,
@@ -777,7 +852,15 @@ class CKKSInferenceContext:
             rotations.extend(extra_rotations)
             rotations = sorted(list(set(rotations)))
         
-        return cls(config, rotations=rotations, use_bsgs=use_bsgs, max_rotation_dim=max_dim, batch_size=batch_size, **kwargs)
+        return cls(
+            config,
+            rotations=rotations,
+            use_bsgs=use_bsgs,
+            max_rotation_dim=max_dim,
+            batch_size=batch_size,
+            architecture=architecture,
+            **kwargs,
+        )
     
     @classmethod
     def for_depth(
@@ -801,6 +884,7 @@ class CKKSInferenceContext:
             "bootstrap_threshold",
             "cnn_config",
             "enable_gpu",
+            "architecture",
         }
 
         config_kwargs = {k: v for k, v in kwargs.items() if k in config_keys}
@@ -837,6 +921,7 @@ class CKKSInferenceContext:
             "auto_bootstrap": self._auto_bootstrap,
             "bootstrap_threshold": self._bootstrap_threshold,
             "batch_size": self._batch_size,
+            "architecture": self._architecture,
         }
         with open(path, "wb") as f:
             pickle.dump(config_data, f)
@@ -869,6 +954,7 @@ class CKKSInferenceContext:
             auto_bootstrap=config_data["auto_bootstrap"],
             bootstrap_threshold=config_data["bootstrap_threshold"],
             batch_size=config_data.get("batch_size", 1),
+            architecture=config_data.get("architecture", "default"),
         )
     
     load = load_context

--- a/cukks/converter.py
+++ b/cukks/converter.py
@@ -33,9 +33,11 @@ from .nn import (
     EncryptedBatchNorm1d,
     EncryptedBatchNorm2d,
     EncryptedLayerNorm,
+    EncryptedInverseFreeLayerNorm,
     EncryptedDropout,
     EncryptedApproxAttention,
 )
+from .analysis import detect_inverse_free_layernorms
 from .nn.batchnorm import fold_batchnorm_into_linear, fold_batchnorm_into_conv
 from .nn.block_diagonal import BlockDiagonalLinear
 from .nn.block_diagonal_low_rank import BlockDiagLowRankLinear
@@ -69,6 +71,9 @@ class ConversionOptions:
         use_square_activation: If True, replace all activations with x^2.
         optimize_cnn: If True, apply CNN-specific optimizations (Flatten absorption).
         batch_size: Number of samples to pack per ciphertext for packed-batch inference.
+        attention_normalization_mode: Multi-token attention normalization kernel.
+        attention_gaussian_gamma: Scale factor for gaussian attention mode.
+        architecture: Conversion architecture profile.
     """
     
     def __init__(
@@ -79,13 +84,24 @@ class ConversionOptions:
         use_square_activation: bool = False,
         optimize_cnn: bool = True,
         batch_size: int = 1,
+        attention_normalization_mode: str = "power_softmax",
+        attention_gaussian_gamma: float = 0.25,
+        architecture: str = "default",
     ):
+        if architecture not in {"default", "stip"}:
+            raise ValueError(
+                "architecture must be 'default' or 'stip', "
+                f"got {architecture!r}"
+            )
         self.fold_batchnorm = fold_batchnorm
         self.activation_degree = activation_degree
         self.activation_map = activation_map if activation_map is not None else DEFAULT_ACTIVATION_MAP.copy()
         self.use_square_activation = use_square_activation
         self.optimize_cnn = optimize_cnn
         self.batch_size = batch_size
+        self.attention_normalization_mode = attention_normalization_mode
+        self.attention_gaussian_gamma = attention_gaussian_gamma
+        self.architecture = architecture
 
 
 # =============================================================================
@@ -145,6 +161,12 @@ class ModelConverter:
         self._is_cnn_model = False
         self._last_cnn_layout: Optional[Dict] = None
         self._pending_flatten = False
+
+        # Inverse-free LayerNorm: set of module names eligible for conversion.
+        # Populated by torch.fx analysis in convert().
+        self._inverse_free_ln_names: frozenset[str] = frozenset()
+        # Track the current module path during recursive conversion
+        self._current_path: List[str] = []
     
     def convert(
         self,
@@ -173,6 +195,10 @@ class ModelConverter:
             self._is_cnn_model = self._detect_cnn(model)
             if self._is_cnn_model:
                 self._analyze_cnn_structure(model)
+
+        # Detect LayerNorms eligible for inverse-free conversion
+        if self.options.architecture == "stip":
+            self._inverse_free_ln_names = detect_inverse_free_layernorms(model)
         
         # Convert the model
         return self._convert_module(model)
@@ -276,11 +302,15 @@ class ModelConverter:
                         continue
             
             try:
+                self._current_path.append(name)
                 converted[name] = self._convert_module(child)
             except NotImplementedError:
                 if isinstance(child, nn.Identity):
+                    self._current_path.pop()
                     continue
+                self._current_path.pop()
                 raise
+            self._current_path.pop()
         return EncryptedSequential(converted)
     
     def _convert_linear(self, module: nn.Linear) -> EncryptedModule:
@@ -345,11 +375,15 @@ class ModelConverter:
                         continue
             
             try:
+                self._current_path.append(name)
                 converted[name] = self._convert_module(child)
             except NotImplementedError:
                 if isinstance(child, nn.Identity):
+                    self._current_path.pop()
                     continue
+                self._current_path.pop()
                 raise
+            self._current_path.pop()
                 
         return EncryptedSequential(converted)
     
@@ -531,11 +565,19 @@ class ModelConverter:
         p = getattr(module, 'p', 0.5)
         return EncryptedDropout(p=p)
     
-    def _convert_layernorm(self, module: nn.LayerNorm) -> EncryptedLayerNorm:
+    def _convert_layernorm(self, module: nn.LayerNorm) -> EncryptedModule:
+        current_name = ".".join(self._current_path)
+        if current_name in self._inverse_free_ln_names:
+            return EncryptedInverseFreeLayerNorm.from_torch(module)
         return EncryptedLayerNorm.from_torch(module)
     
     def _convert_attention(self, module: nn.MultiheadAttention) -> EncryptedApproxAttention:
-        return EncryptedApproxAttention.from_torch(module)
+        return EncryptedApproxAttention.from_torch(
+            module,
+            softmax_degree=self.options.activation_degree,
+            normalization_mode=self.options.attention_normalization_mode,
+            gaussian_gamma=self.options.attention_gaussian_gamma,
+        )
     
     def _convert_maxpool2d(self, module: nn.MaxPool2d) -> EncryptedMaxPool2d:
         """Convert a MaxPool2d layer."""
@@ -658,6 +700,9 @@ def convert(
     bootstrap_threshold: int = 8,
     pre_encode: bool = False,
     batch_size: int = 1,
+    attention_normalization_mode: str = "power_softmax",
+    attention_gaussian_gamma: float = 0.25,
+    architecture: str = "default",
 ) -> Tuple[EncryptedModule, CKKSInferenceContext]:
     """Convert a PyTorch model to an encrypted version.
     
@@ -683,6 +728,9 @@ def convert(
             Requires ``input_shape`` for CNN models.
         batch_size: Number of samples to pack per ciphertext. When > 1, rotation
             keys include cross-block offsets for native packed-batch inference.
+        attention_normalization_mode: Multi-token attention normalization kernel.
+        attention_gaussian_gamma: Scale factor for gaussian attention mode.
+        architecture: Conversion architecture profile.
         
     Returns:
         Tuple of (encrypted_model, context).
@@ -715,6 +763,9 @@ def convert(
         use_square_activation=use_square_activation,
         optimize_cnn=optimize_cnn,
         batch_size=batch_size,
+        attention_normalization_mode=attention_normalization_mode,
+        attention_gaussian_gamma=attention_gaussian_gamma,
+        architecture=architecture,
     )
     
     converter = ModelConverter(options, input_shape=input_shape)
@@ -734,6 +785,7 @@ def convert(
             model,
             activation_degree=activation_degree,
             use_square_activation=use_square_activation,
+            attention_normalization_mode=attention_normalization_mode,
         )
         enable_bootstrap = est_depth > _AUTO_BOOTSTRAP_DEPTH_THRESHOLD
     if auto_bootstrap is None:
@@ -750,6 +802,7 @@ def convert(
             bootstrap_threshold=bootstrap_threshold,
             enable_bootstrap=enable_bootstrap,
             batch_size=batch_size,
+            architecture=architecture,
         )
     
     if cnn_config is not None and hasattr(converter, '_last_cnn_layout') and converter._last_cnn_layout:
@@ -889,13 +942,18 @@ def warm_cache(
     _ = enc_model(enc_input)
 
 
-def estimate_depth(model: nn.Module, activation_degree: int = 4) -> int:
+def estimate_depth(
+    model: nn.Module,
+    activation_degree: int = 4,
+    attention_normalization_mode: str = "power_softmax",
+) -> int:
     """Estimate the multiplicative depth required for a model.
     
     Args:
         model: The PyTorch model to analyze.
         activation_degree: Polynomial degree used for activation approximation.
             Default is 4, matching ConversionOptions default.
+        attention_normalization_mode: Multi-token attention normalization kernel.
         
     Returns:
         Estimated multiplicative depth.
@@ -910,6 +968,8 @@ def estimate_depth(model: nn.Module, activation_degree: int = 4) -> int:
     for module in model.modules():
         if isinstance(module, (nn.Linear, nn.Conv2d)):
             depth += 1  # matmul
+        elif isinstance(module, nn.MultiheadAttention):
+            depth += 9 if attention_normalization_mode == "gaussian" else 10
         elif isinstance(module, (nn.ReLU, nn.GELU, nn.SiLU, nn.Sigmoid, nn.Tanh)):
             depth += poly_depth  # polynomial approximation
     return max(1, depth)

--- a/cukks/nn/__init__.py
+++ b/cukks/nn/__init__.py
@@ -42,6 +42,7 @@ from .flatten import EncryptedFlatten
 from .sequential import EncryptedSequential
 from .batchnorm import EncryptedBatchNorm1d, EncryptedBatchNorm2d
 from .layernorm import EncryptedLayerNorm
+from .inverse_free_layernorm import EncryptedInverseFreeLayerNorm
 from .dropout import EncryptedDropout
 from .residual import EncryptedResidualBlock
 from .attention import EncryptedApproxAttention
@@ -70,4 +71,5 @@ __all__ = [
     "EncryptedDropout",
     "EncryptedResidualBlock",
     "EncryptedApproxAttention",
+    "EncryptedInverseFreeLayerNorm",
 ]

--- a/cukks/nn/attention.py
+++ b/cukks/nn/attention.py
@@ -8,12 +8,17 @@ All attention computations run in pure HE using cipher-cipher operations.
 
 from __future__ import annotations
 
+import functools
 import math
-from typing import TYPE_CHECKING, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
+import numpy as np
 import torch
+from numpy.polynomial.chebyshev import cheb2poly, chebfit
+import cukks.batching as batching_module
 
 from .module import EncryptedModule
+from cukks.stats.crypto_reciprocal import _compute_reciprocal_coeffs
 
 if TYPE_CHECKING:
     from ..tensor import EncryptedTensor
@@ -37,6 +42,23 @@ def _taylor_exp_coeffs(degree: int) -> List[float]:
             factorial *= i
         coeffs.append(1.0 / factorial)
     return coeffs
+
+
+@functools.lru_cache(maxsize=8)
+def _gaussian_exp_coeffs(domain: tuple[float, float], degree: int) -> List[float]:
+    a, b = domain
+
+    def g(t: float) -> float:
+        x = (b - a) * (t + 1) / 2 + a
+        return float(math.exp(-x))
+
+    n_nodes = 100
+    nodes = np.cos((2 * np.arange(n_nodes) + 1) * np.pi / (2 * n_nodes))
+    values = np.array([g(t) for t in nodes])
+
+    cheb_coeffs = chebfit(nodes, values, degree)
+    power_coeffs = cheb2poly(cheb_coeffs)
+    return power_coeffs.tolist()
 
 
 class EncryptedApproxAttention(EncryptedModule):
@@ -71,6 +93,8 @@ class EncryptedApproxAttention(EncryptedModule):
         embed_dim: int,
         num_heads: int,
         softmax_degree: int = 4,
+        normalization_mode: str = "power_softmax",
+        gaussian_gamma: float = 0.25,
     ) -> None:
         super().__init__()
         
@@ -83,12 +107,24 @@ class EncryptedApproxAttention(EncryptedModule):
         self.num_heads = num_heads
         self.head_dim = embed_dim // num_heads
         self.softmax_degree = softmax_degree
+        if normalization_mode not in {"power_softmax", "gaussian"}:
+            raise ValueError(
+                "normalization_mode must be 'power_softmax' or 'gaussian', "
+                f"got {normalization_mode!r}"
+            )
+        if gaussian_gamma <= 0.0:
+            raise ValueError(f"gaussian_gamma must be positive, got {gaussian_gamma}")
+        self.normalization_mode = normalization_mode
+        self.gaussian_gamma = gaussian_gamma
+        self._gaussian_domain = (0.0, 4.0)
         
         # Scale factor for attention scores
         self.scale = 1.0 / math.sqrt(self.head_dim)
         
         # Taylor coefficients for exp(x) approximation
         self._exp_coeffs = _taylor_exp_coeffs(softmax_degree)
+        self._gaussian_exp_coeffs = _gaussian_exp_coeffs(self._gaussian_domain, softmax_degree)
+        self._reciprocal_degree = 15
         
         # Projection weights (initialized as identity for now)
         # These can be set via from_torch or manually
@@ -137,6 +173,148 @@ class EncryptedApproxAttention(EncryptedModule):
                     mask[pos] = 1.0
         return mask
 
+    def _precompute_packed_metadata(
+        self,
+        x: "EncryptedTensor",
+        seq_len: int,
+        embed_dim: int,
+    ) -> tuple[list[list[float]], list[list[float]], list[list[float]], set[int], torch.Tensor]:
+        query_masks = [self._packed_token_mask(x, token_index, seq_len) for token_index in range(seq_len)]
+        power_outside_fills = [
+            [-2.0 * (1.0 - value) for value in query_mask]
+            for query_mask in query_masks
+        ]
+        gaussian_distance_cap = self._gaussian_domain[1] / self.gaussian_gamma
+        gaussian_outside_fills = [
+            [gaussian_distance_cap * (1.0 - value) for value in query_mask]
+            for query_mask in query_masks
+        ]
+        rotation_offsets = {
+            (key_index - query_index) * embed_dim
+            for query_index in range(seq_len)
+            for key_index in range(seq_len)
+        }
+        ones_block = torch.ones(embed_dim, embed_dim, dtype=torch.float64)
+        return query_masks, power_outside_fills, gaussian_outside_fills, rotation_offsets, ones_block
+
+    def _validate_stip_layout(self, x: "EncryptedTensor") -> tuple[int, int]:
+        layout = getattr(x, "_packing_layout", None)
+        if layout is None:
+            raise RuntimeError("STIP attention requires packing layout metadata")
+        if not getattr(x, "_stip_layout_fresh", False):
+            raise RuntimeError("STIP attention requires fresh sequence-layout provenance")
+        if layout.d_model != self.embed_dim:
+            raise RuntimeError(
+                f"STIP attention expected d_model={self.embed_dim}, got {layout.d_model}."
+            )
+        if layout.num_heads != self.num_heads:
+            raise RuntimeError(
+                f"STIP attention expected num_heads={self.num_heads}, got {layout.num_heads}."
+            )
+        if x.shape != (layout.seq_len, layout.d_model):
+            raise RuntimeError(
+                "STIP attention requires tensor shape matching layout. "
+                f"Got tensor shape {x.shape} and layout {(layout.seq_len, layout.d_model)}."
+            )
+        if layout.block_size != layout.d_model:
+            raise NotImplementedError(
+                "STIP attention currently requires block_size == d_model. "
+                f"Got block_size={layout.block_size}, d_model={layout.d_model}."
+            )
+        if layout.total_slots_needed > x._cipher.size:
+            raise RuntimeError(
+                "STIP attention layout exceeds ciphertext capacity. "
+                f"Need {layout.total_slots_needed} slots, have {x._cipher.size}."
+            )
+        if layout.seq_len > 8:
+            raise NotImplementedError(
+                f"seq_len={layout.seq_len} not supported. Maximum is 8 for {self.normalization_mode} attention."
+            )
+        return layout.seq_len, layout.d_model
+
+    def _forward_attention_stip(self, x: "EncryptedTensor") -> "EncryptedTensor":
+        seq_len, embed_dim = self._validate_stip_layout(x)
+        layout = x._packing_layout
+        assert layout is not None
+
+        packed_x = x.clone()
+        packed_x._packed_batch = True
+        packed_x._batch_size = 1
+        packed_x._slots_per_sample = seq_len * embed_dim
+        packed_x._packed_sample_shape = (seq_len, embed_dim)
+        packed_x._stip_layout_fresh = False
+
+        output = self._forward_attention_packed(packed_x)
+        output._packed_batch = False
+        output._batch_size = None
+        output._slots_per_sample = None
+        output._packed_sample_shape = None
+        output._shape = (seq_len, embed_dim)
+        output._packing_layout = layout
+        output._stip_layout_fresh = True
+        return output
+
+    def _normalize_positive_scores(
+        self,
+        scores: List["EncryptedTensor"],
+        eps: float = 0.01,
+        reciprocal_domain: tuple[float, float] = (0.5, 150.0),
+        renorm_reciprocal_domain: tuple[float, float] = (0.5, 10.0),
+        renormalize: bool = True,
+        reciprocal_fill: Optional[List[float]] = None,
+        renorm_reciprocal_fill: Optional[List[float]] = None,
+    ) -> List["EncryptedTensor"]:
+        from cukks.stats.crypto_reciprocal import crypto_reciprocal_shallow
+
+        z_sum = scores[0]
+        for score in scores[1:]:
+            z_sum = z_sum.add(score)
+
+        z_sum_safe = z_sum.add(eps)
+        if reciprocal_fill is not None:
+            z_sum_safe = z_sum_safe.add(reciprocal_fill)
+        inv_z_sum = crypto_reciprocal_shallow(z_sum_safe, domain=reciprocal_domain)
+        weights = [score.mul(inv_z_sum).rescale() for score in scores]
+
+        if not renormalize:
+            return weights
+
+        weight_sum = weights[0]
+        for weight in weights[1:]:
+            weight_sum = weight_sum.add(weight)
+
+        weight_sum_safe = weight_sum.add(eps)
+        if renorm_reciprocal_fill is not None:
+            weight_sum_safe = weight_sum_safe.add(renorm_reciprocal_fill)
+        inv_weight_sum = crypto_reciprocal_shallow(weight_sum_safe, domain=renorm_reciprocal_domain)
+        return [weight.mul(inv_weight_sum).rescale() for weight in weights]
+
+    def _power_reciprocal_domain(self, num_scores: int, shift: float) -> tuple[float, float]:
+        margin = 0.5
+        lower = max(0.5, float(num_scores) * max(shift - margin, 0.25) ** 2)
+        upper = max(lower + 1.0, float(num_scores) * (shift + margin) ** 2)
+        return (lower, upper)
+
+    def _power_renorm_reciprocal_domain(self) -> tuple[float, float]:
+        return (0.75, 1.25)
+
+    def _power_reciprocal_coeffs_for(self, num_scores: int, shift: float) -> list[float]:
+        return _compute_reciprocal_coeffs(
+            self._power_reciprocal_domain(num_scores, shift),
+            degree=self._reciprocal_degree,
+        )
+
+    def _power_renorm_reciprocal_coeffs_for(self) -> list[float]:
+        return _compute_reciprocal_coeffs(
+            self._power_renorm_reciprocal_domain(),
+            degree=self._reciprocal_degree,
+        )
+
+    def _gaussian_reciprocal_domain(self, num_scores: int) -> tuple[float, float]:
+        lower = max(0.05, 0.5 * float(num_scores) * math.exp(-self._gaussian_domain[1]))
+        upper = float(num_scores) + 0.5
+        return (lower, upper)
+
     def _forward_attention_packed(self, x: "EncryptedTensor") -> "EncryptedTensor":
         sample_shape = getattr(x, "_packed_sample_shape", None) or x.shape[1:]
         if len(sample_shape) == 1:
@@ -162,34 +340,79 @@ class EncryptedApproxAttention(EncryptedModule):
 
         seq_len = sample_shape[0]
         embed_dim = sample_shape[1]
-        ones_block = torch.ones(embed_dim, embed_dim, dtype=torch.float64)
+        if seq_len > 8:
+            raise NotImplementedError(
+                f"seq_len={seq_len} not supported. Maximum is 8 for {self.normalization_mode} attention."
+            )
+        query_masks, power_outside_fills, gaussian_outside_fills, rotation_offsets, ones_block = self._precompute_packed_metadata(
+            x,
+            seq_len,
+            embed_dim,
+        )
 
         q = self._apply_projection(x, self.q_weight, self.q_bias)
         k = self._apply_projection(x, self.k_weight, self.k_bias)
         v = self._apply_projection(x, self.v_weight, self.v_bias)
+        if (
+            self.normalization_mode == "power_softmax"
+            and hasattr(q._cipher, "packed_self_attention_power")
+            and not hasattr(q._cipher, "_backend")
+        ):
+            combined = q.packed_self_attention_power(
+                k,
+                v,
+                batch_size=getattr(x, "_batch_size", 1),
+                seq_len=seq_len,
+                embed_dim=embed_dim,
+                scale=self.scale,
+                shift=2.0,
+                reciprocal_coeffs=self._power_reciprocal_coeffs_for(seq_len, shift=2.0),
+                renorm_reciprocal_coeffs=self._power_renorm_reciprocal_coeffs_for(),
+            )
+            combined = combined.rescale()
+            combined = self._apply_projection(combined, self.out_weight, self.out_bias)
+            return combined.view(*x.shape)
+        rotated_k = {0: k}
+        rotated_v = {0: v}
+        for offset in rotation_offsets:
+            if offset == 0:
+                continue
+            rotated_k[offset] = k.rotate(offset)
+            rotated_v[offset] = v.rotate(offset)
 
         outputs = []
         for query_index in range(seq_len):
-            query_mask = self._packed_token_mask(x, query_index, seq_len)
-            outside_fill = [-2.0 * (1.0 - value) for value in query_mask]
-            scores = []
+            query_mask = query_masks[query_index]
+            reciprocal_fill = [1.0 - value for value in query_mask]
+            power_outside_fill = power_outside_fills[query_index]
+            gaussian_outside_fill = gaussian_outside_fills[query_index]
+            score_terms = []
             for key_index in range(seq_len):
                 offset = (key_index - query_index) * embed_dim
-                aligned_product = q.mul(k.rotate(offset)).rescale()
-                masked_scores = aligned_product.mul(query_mask).rescale()
-                score = masked_scores.view(getattr(x, "_batch_size", 1), seq_len, embed_dim).matmul(ones_block)
-                score = score.mul(self.scale).rescale()
-                score = score.add(outside_fill)
-                scores.append(score)
+                if self.normalization_mode == "gaussian":
+                    diff = q.sub(rotated_k[offset])
+                    squared_diff = diff.mul(diff).rescale()
+                    masked_scores = squared_diff.mul(query_mask).rescale()
+                    score = masked_scores.view(getattr(x, "_batch_size", 1), seq_len, embed_dim).matmul(ones_block)
+                    score = score.mul(self.scale).rescale()
+                    score_terms.append(score.add(gaussian_outside_fill))
+                else:
+                    aligned_product = q.mul(rotated_k[offset]).rescale()
+                    masked_scores = aligned_product.mul(query_mask).rescale()
+                    score = masked_scores.view(getattr(x, "_batch_size", 1), seq_len, embed_dim).matmul(ones_block)
+                    score = score.mul(self.scale).rescale()
+                    score = score.add(power_outside_fill)
+                    score_terms.append(score)
 
-            weights = self._power_softmax(scores)
+            weights = self._compute_attention_weights(score_terms, reciprocal_fill=reciprocal_fill)
             token_output = None
             for key_index, weight in enumerate(weights):
                 offset = (key_index - query_index) * embed_dim
-                term = weight.mul(v.rotate(offset)).rescale()
+                term = weight.mul(rotated_v[offset]).rescale()
                 token_output = term if token_output is None else token_output.add(term)
 
             assert token_output is not None
+            token_output = token_output.mul(query_mask).rescale()
             outputs.append(token_output)
 
         combined = outputs[0]
@@ -206,11 +429,267 @@ class EncryptedApproxAttention(EncryptedModule):
         product = a.mul(b).rescale()
         return product.sum_and_broadcast(dim)
 
+    def _pcmm(
+        self,
+        columns: list["EncryptedTensor"],
+        weight: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> list["EncryptedTensor"]:
+        """Plaintext-Ciphertext Matrix Multiply (column-wise)."""
+        d_in = len(columns)
+        w = weight.to(dtype=torch.float64)
+        if w.ndim != 2:
+            raise ValueError(f"Expected rank-2 weight matrix, got shape {tuple(w.shape)}")
+        if w.shape[0] != d_in and w.shape[1] != d_in:
+            raise ValueError(
+                "Weight is incompatible with input columns: "
+                f"d_in={d_in}, weight_shape={tuple(w.shape)}"
+            )
+        if w.shape[0] != d_in:
+            w = w.T
+
+        out_cols: list["EncryptedTensor"] = []
+        for out_idx in range(w.shape[1]):
+            acc: Optional["EncryptedTensor"] = None
+            for in_idx in range(d_in):
+                coeff = float(w[in_idx, out_idx])
+                if abs(coeff) < 1e-30:
+                    continue
+                term = columns[in_idx].mul(coeff)
+                acc = term if acc is None else acc.add(term)
+
+            if acc is None:
+                acc = columns[0].mul(0.0)
+            acc = acc.rescale()
+            if bias is not None:
+                acc = acc.add(float(bias[out_idx]))
+            out_cols.append(acc)
+        return out_cols
+
+    def _diagonal_softmax(self, score_diagonals: list["EncryptedTensor"]) -> list["EncryptedTensor"]:
+        """Apply configured attention normalization to diagonal scores."""
+        return self._compute_attention_weights(score_diagonals)
+
+    def _head_attention_from_columns(
+        self,
+        q_head: list["EncryptedTensor"],
+        k_head: list["EncryptedTensor"],
+        v_head: list["EncryptedTensor"],
+        seq_len: int,
+        rihp: Optional[Any],
+    ) -> list["EncryptedTensor"]:
+        if rihp is not None:
+            k_hybrid = rihp.pack_hybrid(k_head)
+            hybrid_diags = rihp.halved_ccmm(q_head, k_hybrid)
+            score_diags = rihp.unpack_diagonals(hybrid_diags)
+        else:
+            score_diags = []
+            for rotation in range(seq_len):
+                acc = q_head[0].mul(k_head[0].rotate(rotation)).rescale()
+                for col_idx in range(1, self.head_dim):
+                    term = q_head[col_idx].mul(k_head[col_idx].rotate(rotation)).rescale()
+                    acc = acc.add(term)
+                score_diags.append(acc)
+
+        scaled_scores = [diag.mul(self.scale).rescale() for diag in score_diags]
+        weights_diags = self._diagonal_softmax(scaled_scores)
+
+        out_cols: list["EncryptedTensor"] = []
+        for col_idx in range(self.head_dim):
+            acc = weights_diags[0].mul(v_head[col_idx]).rescale()
+            for rotation in range(1, seq_len):
+                term = weights_diags[rotation].mul(v_head[col_idx].rotate(rotation)).rescale()
+                acc = acc.add(term)
+            out_cols.append(acc)
+        return out_cols
+
+    def forward_stip_columns_dhp(
+        self,
+        x_columns: list["EncryptedTensor"],
+        seq_len: int,
+    ) -> list["EncryptedTensor"]:
+        """Column-wise STIP attention with DHP projection packing."""
+        if self.num_heads % 2 != 0:
+            raise ValueError("forward_stip_columns_dhp requires even num_heads")
+
+        d_model = len(x_columns)
+        if d_model != self.embed_dim:
+            raise ValueError(f"Expected {self.embed_dim} columns, got {d_model}")
+
+        pairer = batching_module.DHPacker(self.num_heads)
+        use_rihp = seq_len % 2 == 0
+        rihp = batching_module.RIHPacker(seq_len) if use_rihp else None
+        all_repacked: list["EncryptedTensor"] = []
+
+        if self.q_weight is not None:
+            if self.k_weight is None or self.v_weight is None:
+                raise RuntimeError("q/k/v weights must all be set or all be None")
+
+            q_w = self.q_weight.to(dtype=torch.float64)
+            k_w = self.k_weight.to(dtype=torch.float64)
+            v_w = self.v_weight.to(dtype=torch.float64)
+            if q_w.shape[0] != d_model:
+                q_w = q_w.T
+            if k_w.shape[0] != d_model:
+                k_w = k_w.T
+            if v_w.shape[0] != d_model:
+                v_w = v_w.T
+
+            for pair_idx in range(pairer.num_pairs):
+                left_start = pair_idx * 2 * self.head_dim
+                left_end = left_start + self.head_dim
+                right_start = left_end
+                right_end = right_start + self.head_dim
+
+                q_precoded = batching_module.DHPacker.precode_weights(q_w[:, left_start:left_end], q_w[:, right_start:right_end])
+                k_precoded = batching_module.DHPacker.precode_weights(k_w[:, left_start:left_end], k_w[:, right_start:right_end])
+                v_precoded = batching_module.DHPacker.precode_weights(v_w[:, left_start:left_end], v_w[:, right_start:right_end])
+
+                q_packed = pairer.parallel_projection(x_columns, q_precoded.tolist())
+                k_packed = pairer.parallel_projection(x_columns, k_precoded.tolist())
+                v_packed = pairer.parallel_projection(x_columns, v_precoded.tolist())
+
+                q_left, q_right = pairer.unpack_heads(q_packed)
+                k_left, k_right = pairer.unpack_heads(k_packed)
+                v_left, v_right = pairer.unpack_heads(v_packed)
+
+                for col_idx in range(self.head_dim):
+                    if self.q_bias is not None:
+                        q_left[col_idx] = q_left[col_idx].add(float(self.q_bias[left_start + col_idx]))
+                        q_right[col_idx] = q_right[col_idx].add(float(self.q_bias[right_start + col_idx]))
+                    if self.k_bias is not None:
+                        k_left[col_idx] = k_left[col_idx].add(float(self.k_bias[left_start + col_idx]))
+                        k_right[col_idx] = k_right[col_idx].add(float(self.k_bias[right_start + col_idx]))
+                    if self.v_bias is not None:
+                        v_left[col_idx] = v_left[col_idx].add(float(self.v_bias[left_start + col_idx]))
+                        v_right[col_idx] = v_right[col_idx].add(float(self.v_bias[right_start + col_idx]))
+
+                out_left = self._head_attention_from_columns(q_left, k_left, v_left, seq_len, rihp)
+                out_right = self._head_attention_from_columns(q_right, k_right, v_right, seq_len, rihp)
+                repacked = pairer.repack_after_attention(out_left, out_right)
+
+                all_repacked.extend(repacked)
+        else:
+            for pair_idx in range(pairer.num_pairs):
+                left_start = pair_idx * 2 * self.head_dim
+                left_end = left_start + self.head_dim
+                right_start = left_end
+                right_end = right_start + self.head_dim
+
+                out_left = self._head_attention_from_columns(
+                    x_columns[left_start:left_end],
+                    x_columns[left_start:left_end],
+                    x_columns[left_start:left_end],
+                    seq_len,
+                    rihp,
+                )
+                out_right = self._head_attention_from_columns(
+                    x_columns[right_start:right_end],
+                    x_columns[right_start:right_end],
+                    x_columns[right_start:right_end],
+                    seq_len,
+                    rihp,
+                )
+                repacked = pairer.repack_after_attention(out_left, out_right)
+                all_repacked.extend(repacked)
+
+        if self.out_weight is None:
+            out_cols: list["EncryptedTensor"] = []
+            for pair_idx in range(pairer.num_pairs):
+                pair_start = pair_idx * self.head_dim
+                pair_end = pair_start + self.head_dim
+                left, right = pairer.unpack_heads(all_repacked[pair_start:pair_end])
+                out_cols.extend(left)
+                out_cols.extend(right)
+            return out_cols
+
+        out_w = self.out_weight.to(dtype=torch.float64)
+        if out_w.shape[0] != self.embed_dim:
+            out_w = out_w.T
+
+        final_outputs: list["EncryptedTensor"] = []
+        for out_idx in range(self.embed_dim):
+            pair_accum: Optional["EncryptedTensor"] = None
+            for pair_idx in range(pairer.num_pairs):
+                left_start = pair_idx * 2 * self.head_dim
+                left_end = left_start + self.head_dim
+                right_start = left_end
+                right_end = right_start + self.head_dim
+
+                packed_pair = all_repacked[pair_idx * self.head_dim : (pair_idx + 1) * self.head_dim]
+                left_weights = out_w[left_start:left_end, out_idx]
+                right_weights = out_w[right_start:right_end, out_idx]
+                precoded = batching_module.DHPacker.precode_weights(left_weights.unsqueeze(1), -right_weights.unsqueeze(1))
+                pair_proj = pairer.parallel_projection(packed_pair, precoded.tolist())
+                if not pair_proj:
+                    continue
+                pair_term = pair_proj[0]
+                pair_accum = pair_term if pair_accum is None else pair_accum.add(pair_term)
+
+            if pair_accum is None:
+                pair_accum = x_columns[0].mul(0.0)
+            final_col = pairer.extract_final(pair_accum).rescale()
+            if self.out_bias is not None:
+                final_col = final_col.add(float(self.out_bias[out_idx]))
+            final_outputs.append(final_col)
+
+        return final_outputs
+
+    def forward_stip_columns(
+        self,
+        x_columns: list["EncryptedTensor"],
+        seq_len: int,
+    ) -> list["EncryptedTensor"]:
+        """Column-wise STIP attention using RIHP + optional DHP projection packing."""
+        d_model = len(x_columns)
+        if d_model != self.embed_dim:
+            raise ValueError(f"Expected {self.embed_dim} columns, got {d_model}")
+        if seq_len <= 0:
+            raise ValueError(f"seq_len must be positive, got {seq_len}")
+        if seq_len > 8:
+            raise NotImplementedError(
+                f"seq_len={seq_len} not supported. Maximum is 8 for {self.normalization_mode} attention."
+            )
+
+        if self.num_heads % 2 == 0:
+            return self.forward_stip_columns_dhp(x_columns, seq_len)
+
+        if self.q_weight is not None:
+            if self.k_weight is None or self.v_weight is None:
+                raise RuntimeError("q/k/v weights must all be set or all be None")
+            q_cols = self._pcmm(x_columns, self.q_weight, self.q_bias)
+            k_cols = self._pcmm(x_columns, self.k_weight, self.k_bias)
+            v_cols = self._pcmm(x_columns, self.v_weight, self.v_bias)
+        else:
+            q_cols = list(x_columns)
+            k_cols = list(x_columns)
+            v_cols = list(x_columns)
+
+        rihp = batching_module.RIHPacker(seq_len) if seq_len % 2 == 0 else None
+        all_out_cols: list["EncryptedTensor"] = []
+        for head_idx in range(self.num_heads):
+            start = head_idx * self.head_dim
+            end = start + self.head_dim
+            all_out_cols.extend(
+                self._head_attention_from_columns(
+                    q_cols[start:end],
+                    k_cols[start:end],
+                    v_cols[start:end],
+                    seq_len,
+                    rihp,
+                )
+            )
+
+        if self.out_weight is not None:
+            all_out_cols = self._pcmm(all_out_cols, self.out_weight, self.out_bias)
+        return all_out_cols
+
     def _power_softmax(
         self,
         scores: List["EncryptedTensor"],
         shift: float = 2.0,
         eps: float = 0.01,
+        reciprocal_fill: Optional[List[float]] = None,
     ) -> List["EncryptedTensor"]:
         """Compute Power-Softmax (p=2) for attention weights.
 
@@ -219,31 +698,52 @@ class EncryptedApproxAttention(EncryptedModule):
         Z = sum(u_j)
         w_j = u_j / Z
         """
-        from cukks.stats.crypto_reciprocal import crypto_reciprocal_shallow
-
         shifted = [s.add(shift) for s in scores]
         # Ensure shifted scores are rescaled before squaring.
         # If scores came from a mul (degree 2), squaring without rescale
         # would produce degree 4, causing rapid noise growth or decryption failure.
         shifted = [t._ensure_rescaled() for t in shifted]
         squared = [t.mul(t).rescale() for t in shifted]
+        return self._normalize_positive_scores(
+            squared,
+            eps=eps,
+            reciprocal_domain=self._power_reciprocal_domain(len(scores), shift),
+            renorm_reciprocal_domain=self._power_renorm_reciprocal_domain(),
+            renormalize=False,
+            reciprocal_fill=reciprocal_fill,
+        )
 
-        z_sum = squared[0]
-        for u in squared[1:]:
-            z_sum = z_sum.add(u)
+    def _gaussian_kernel_weights(
+        self,
+        distances: List["EncryptedTensor"],
+        eps: float = 0.01,
+        reciprocal_fill: Optional[List[float]] = None,
+    ) -> List["EncryptedTensor"]:
+        scaled_distances = [distance.mul(self.gaussian_gamma).rescale() for distance in distances]
+        kernels = [self._approx_gaussian_kernel(distance) for distance in scaled_distances]
+        return self._normalize_positive_scores(
+            kernels,
+            eps=eps,
+            reciprocal_domain=self._gaussian_reciprocal_domain(len(distances)),
+            renormalize=False,
+            reciprocal_fill=reciprocal_fill,
+        )
 
-        z_sum_safe = z_sum.add(eps)
-        inv_z_sum = crypto_reciprocal_shallow(z_sum_safe, domain=(0.5, 150.0))
+    def _approx_gaussian_kernel(self, distance: "EncryptedTensor") -> "EncryptedTensor":
+        a, b = self._gaussian_domain
+        alpha = 2.0 / (b - a)
+        beta = -(a + b) / (b - a)
+        t = distance.mul(alpha).rescale().add(beta)
+        return t.poly_eval(self._gaussian_exp_coeffs)
 
-        weights = [u.mul(inv_z_sum).rescale() for u in squared]
-
-        weight_sum = weights[0]
-        for weight in weights[1:]:
-            weight_sum = weight_sum.add(weight)
-
-        inv_weight_sum = crypto_reciprocal_shallow(weight_sum, domain=(0.5, 10.0))
-        weights = [weight.mul(inv_weight_sum).rescale() for weight in weights]
-        return weights
+    def _compute_attention_weights(
+        self,
+        score_terms: List["EncryptedTensor"],
+        reciprocal_fill: Optional[List[float]] = None,
+    ) -> List["EncryptedTensor"]:
+        if self.normalization_mode == "gaussian":
+            return self._gaussian_kernel_weights(score_terms, reciprocal_fill=reciprocal_fill)
+        return self._power_softmax(score_terms, reciprocal_fill=reciprocal_fill)
     
     def _approx_exp(self, x: "EncryptedTensor") -> "EncryptedTensor":
         """Approximate exp(x) using Taylor series.
@@ -277,9 +777,14 @@ class EncryptedApproxAttention(EncryptedModule):
     def forward(self, x: "EncryptedTensor") -> "EncryptedTensor":
         """Self-attention forward pass.
         
-        For self-attention, uses x as query, key, and value.
-        Raises NotImplementedError when seq_len > 1.
+        For self-attention, uses ``x`` as query, key, and value.
+
+        Single encrypted tensors support ``seq_len=1``. Packed encrypted
+        batches with sample shape ``(seq_len, embed_dim)`` support
+        multi-token attention up to ``seq_len=8``.
         """
+        if getattr(x, "_packing_layout", None) is not None:
+            return self._forward_attention_stip(x)
         if getattr(x, "_packed_batch", False):
             return self._forward_attention_packed(x)
         return cast("EncryptedTensor", self.forward_attention(x, x, x))
@@ -297,7 +802,7 @@ class EncryptedApproxAttention(EncryptedModule):
 
         if seq_len > 8:
             raise NotImplementedError(
-                f"seq_len={seq_len} not supported. Maximum is 8 for Power-Softmax attention."
+                f"seq_len={seq_len} not supported. Maximum is 8 for {self.normalization_mode} attention."
             )
          
         if seq_len != len(key) or seq_len != len(value):
@@ -309,13 +814,19 @@ class EncryptedApproxAttention(EncryptedModule):
         
         outputs = []
         for i in range(seq_len):
-            scores = []
+            score_terms = []
             for j in range(seq_len):
-                s_ij = self._ct_dot(q_list[i], k_list[j], self.embed_dim)
-                s_ij = s_ij.mul(self.scale).rescale()
-                scores.append(s_ij)
+                if self.normalization_mode == "gaussian":
+                    diff = q_list[i].sub(k_list[j])
+                    dist_ij = self._ct_dot(diff, diff, self.embed_dim)
+                    dist_ij = dist_ij.mul(self.scale).rescale()
+                    score_terms.append(dist_ij)
+                else:
+                    s_ij = self._ct_dot(q_list[i], k_list[j], self.embed_dim)
+                    s_ij = s_ij.mul(self.scale).rescale()
+                    score_terms.append(s_ij)
             
-            weights = self._power_softmax(scores)
+            weights = self._compute_attention_weights(score_terms)
             
             y_i = weights[0].mul(v_list[0]).rescale()
             for j in range(1, seq_len):
@@ -334,23 +845,28 @@ class EncryptedApproxAttention(EncryptedModule):
     ) -> Union["EncryptedTensor", List["EncryptedTensor"]]:
         """Forward pass of approximate attention using pure HE operations.
         
-        Computes single-token attention using cipher-cipher multiplications
-        and sum_and_broadcast for dot products. No decryption occurs.
-        
-        Currently supports seq_len=1 only. For seq_len>1, encrypted
-        matrix multiplication would require more complex rotation-based
-        algorithms.
+        Supports two public input forms:
+
+        - Single encrypted tensors for ``seq_len=1``
+        - Lists of encrypted tensors for multi-token attention with
+          ``seq_len <= 8`` using the configured normalization mode
+
+        All computation stays in HE with no decryption fallback.
         
         Args:
-            query: Query tensor, shape (embed_dim,) for seq_len=1.
-            key: Key tensor, same shape as query.
-            value: Value tensor, same shape as query.
+            query: Query tensor for ``seq_len=1`` or a list of encrypted
+                per-token tensors for multi-token attention.
+            key: Key tensor/list matching ``query``.
+            value: Value tensor/list matching ``query``.
             
         Returns:
-            Attention output with same shape as input.
+            Encrypted tensor for single-token input or list of encrypted
+            tensors for multi-token input.
             
         Raises:
-            NotImplementedError: If seq_len > 1 (input is 2D with first dim > 1).
+            NotImplementedError: If a single encrypted tensor is passed with
+                ``seq_len > 1`` or if list-based multi-token input exceeds
+                ``seq_len=8``.
         """
         if isinstance(query, list):
             if not isinstance(key, list) or not isinstance(value, list):
@@ -362,7 +878,9 @@ class EncryptedApproxAttention(EncryptedModule):
         # Guard: only seq_len=1 supported
         if len(query.shape) > 1 and query.shape[0] > 1:
             raise NotImplementedError(
-                "EncryptedApproxAttention only supports seq_len=1 in pure HE mode. "
+                "Single-tensor attention requires seq_len=1. For seq_len>1, "
+                "use packed encrypted batches in forward() or pass query/key/value "
+                "as List[EncryptedTensor] with max seq_len=8. "
                 f"Got query shape {query.shape} with seq_len={query.shape[0]}."
             )
         
@@ -416,10 +934,14 @@ class EncryptedApproxAttention(EncryptedModule):
         
         # Q * K cipher×cipher
         depth += 1
-        
-        # Power-Softmax: square + reciprocal + weight multiplication
-        # square: 1, reciprocal: ~4, weight_mul: 1
-        depth += 6
+
+        if self.normalization_mode == "gaussian":
+            gaussian_poly_depth = max(1, math.ceil(math.log2(self.softmax_degree + 1)))
+            depth += 1 + gaussian_poly_depth + 4
+        else:
+            # Power-Softmax: square + reciprocal + weight multiplication
+            # square: 1, reciprocal: ~4, weight_mul: 1
+            depth += 6
         
         # Weighted V sum
         depth += 1
@@ -435,12 +957,16 @@ class EncryptedApproxAttention(EncryptedModule):
         cls,
         attention: torch.nn.MultiheadAttention,
         softmax_degree: int = 4,
+        normalization_mode: str = "power_softmax",
+        gaussian_gamma: float = 0.25,
     ) -> "EncryptedApproxAttention":
         """Create from PyTorch MultiheadAttention.
         
         Args:
             attention: PyTorch MultiheadAttention module.
             softmax_degree: Degree for softmax polynomial approximation.
+            normalization_mode: Multi-token normalization kernel.
+            gaussian_gamma: Scale factor for gaussian attention mode.
             
         Returns:
             EncryptedApproxAttention with copied weights.
@@ -452,6 +978,8 @@ class EncryptedApproxAttention(EncryptedModule):
             embed_dim=embed_dim,
             num_heads=num_heads,
             softmax_degree=softmax_degree,
+            normalization_mode=normalization_mode,
+            gaussian_gamma=gaussian_gamma,
         )
         
         # Extract weights from PyTorch attention
@@ -485,5 +1013,7 @@ class EncryptedApproxAttention(EncryptedModule):
             f"embed_dim={self.embed_dim}, "
             f"num_heads={self.num_heads}, "
             f"head_dim={self.head_dim}, "
-            f"softmax_degree={self.softmax_degree}"
+            f"softmax_degree={self.softmax_degree}, "
+            f"normalization_mode={self.normalization_mode}, "
+            f"gaussian_gamma={self.gaussian_gamma}"
         )

--- a/cukks/nn/inverse_free_layernorm.py
+++ b/cukks/nn/inverse_free_layernorm.py
@@ -1,0 +1,235 @@
+"""
+Inverse-Free LayerNorm for CKKS encrypted inference.
+
+Instead of computing 1/σ (expensive in HE), this module outputs a
+σ-scaled result that the *next* standard LayerNorm will cancel via
+scale-invariance.  See STIP (ePrint 2026/174), Section 5.2.
+
+Algorithm (per-token vector x of dimension n):
+    z_i = x_i - mean(x)                     # centering
+    v   = sqrt(λ · Σ z_i²)                  # scaled std (no 1/σ)
+    y_i = γ · z_i · sqrt(n·λ) + β · v       # inverse-free output
+
+where λ is chosen so that λ·Σz_i² ∈ (0, 2) for the Taylor sqrt.
+
+Depth cost: 5 levels (mean 1, square+sum 1, sqrt 2, final scale 1)
+vs. standard EncryptedLayerNorm: 18 levels.
+
+IMPORTANT: This module is only correct when a subsequent standard
+LayerNorm exists to cancel the residual σ factor.  The converter's
+torch.fx analysis pass ensures this precondition.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+
+import torch
+
+from .module import EncryptedModule
+
+if TYPE_CHECKING:
+    from ..tensor import EncryptedTensor
+
+
+class EncryptedInverseFreeLayerNorm(EncryptedModule):
+    """Inverse-free LayerNorm that avoids 1/σ computation.
+
+    Outputs ``γ · z · sqrt(n·λ) + β · v`` where ``v = sqrt(λ · Σz²)``.
+    The σ scaling factor is cancelled by a downstream standard LayerNorm.
+
+    Args:
+        normalized_shape: Feature dimension(s) to normalize over.
+        weight: Learnable scale γ.  Defaults to ones.
+        bias: Learnable shift β.  Defaults to zeros.
+        eps: Stability constant (unused in forward — kept for API compat).
+        lam: Scaling factor λ that constrains λ·Σz² into (0, 2)
+             for the second-order Taylor sqrt.  Default 0.01 works
+             for typical transformer hidden sizes (256–4096).
+    """
+
+    def __init__(
+        self,
+        normalized_shape: Union[int, List[int], Tuple[int, ...], torch.Size],
+        weight: Optional[torch.Tensor] = None,
+        bias: Optional[torch.Tensor] = None,
+        eps: float = 1e-5,
+        lam: float = 0.01,
+    ) -> None:
+        super().__init__()
+
+        if isinstance(normalized_shape, int):
+            self.normalized_shape: List[int] = [normalized_shape]
+        elif isinstance(normalized_shape, (torch.Size, tuple)):
+            self.normalized_shape = list(normalized_shape)  # pyright: ignore[reportAssignmentType]
+        else:
+            self.normalized_shape = normalized_shape  # pyright: ignore[reportAssignmentType]
+
+        self.eps = eps
+        self.lam = lam
+
+        if weight is not None:
+            self.weight = weight.detach().to(dtype=torch.float64, device="cpu")
+        else:
+            self.weight = torch.ones(self.normalized_shape, dtype=torch.float64)
+
+        if bias is not None:
+            self.bias = bias.detach().to(dtype=torch.float64, device="cpu")
+        else:
+            self.bias = torch.zeros(self.normalized_shape, dtype=torch.float64)
+
+        self.register_parameter("weight", self.weight)
+        self.register_parameter("bias", self.bias)
+
+    # ------------------------------------------------------------------ #
+    #  Forward
+    # ------------------------------------------------------------------ #
+
+    def forward(self, x: "EncryptedTensor") -> "EncryptedTensor":
+        """Apply inverse-free layer normalization.
+
+        Computes:  y_i = γ · z_i · sqrt(n·λ) + β · v
+        where z_i = (1/n)·Σ_j(x_i − x_j), v = sqrt(λ · Σ z_i²).
+
+        Returns:
+            Encrypted tensor carrying a residual σ factor that must be
+            cancelled by a subsequent standard LayerNorm.
+        """
+        n = math.prod(self.normalized_shape)
+        lam = self.lam
+
+        # Pre-compute plaintext constants
+        gamma_sqrt_nl = (
+            self.weight.reshape(-1) * math.sqrt(n * lam)
+        ).tolist()
+        beta_flat = self.bias.reshape(-1).tolist()
+
+        if getattr(x, "_packed_batch", False):
+            return self._forward_packed(x, n, lam, gamma_sqrt_nl, beta_flat)
+        return self._forward_single(x, n, lam, gamma_sqrt_nl, beta_flat)
+
+    # ------------------------------------------------------------------ #
+
+    def _forward_single(
+        self,
+        x: "EncryptedTensor",
+        n: int,
+        lam: float,
+        gamma_sqrt_nl: list[float],
+        beta_flat: list[float],
+    ) -> "EncryptedTensor":
+        # Step 1: Compute z_i = x_i − mean  (depth: 1 for sum_and_broadcast + mul)
+        mean_broadcast = x.sum_and_broadcast(n).mul(1.0 / n).rescale()
+        z = x.sub(mean_broadcast)
+
+        # Step 2: Compute v = sqrt(λ · Σ z_i²)
+        z_sq = z.square().rescale()
+        sum_z_sq = z_sq.sum_and_broadcast(n)  # broadcast so v has same shape
+        lam_sum = sum_z_sq.mul(lam).rescale()
+        v = self._taylor_sqrt(lam_sum)  # depth: 2
+
+        # Step 3: y_i = γ·z_i·sqrt(n·λ) + β·v   (depth: 1)
+        term1 = z.mul(gamma_sqrt_nl).rescale()
+        term2 = v.mul(beta_flat).rescale()
+        result = term1.add(term2)
+
+        # Store σ = v / √(nλ) for downstream bias scaling.
+        # v = √(λ·Σz²) = √(λn)·σ, so σ = v · (1/√(nλ)).
+        sigma = v.mul(1.0 / math.sqrt(n * lam)).rescale()
+        result._sigma_factor = sigma
+        return result
+
+    def _forward_packed(
+        self,
+        x: "EncryptedTensor",
+        n: int,
+        lam: float,
+        gamma_sqrt_nl: list[float],
+        beta_flat: list[float],
+    ) -> "EncryptedTensor":
+        batch_size = getattr(x, "_batch_size", None)
+        sample_shape = getattr(x, "_packed_sample_shape", None) or x.shape[1:]
+        normalized_tail = tuple(self.normalized_shape)
+
+        if batch_size is None:
+            raise RuntimeError(
+                "EncryptedInverseFreeLayerNorm packed path requires batch_size"
+            )
+        if (
+            len(sample_shape) < len(normalized_tail)
+            or tuple(sample_shape[-len(normalized_tail):]) != normalized_tail
+        ):
+            raise RuntimeError(
+                "packed sample shape must end with normalized_shape="
+                f"{normalized_tail}, got {sample_shape}."
+            )
+
+        prefix = (
+            int(math.prod(sample_shape[: -len(normalized_tail)]))
+            if len(sample_shape) > len(normalized_tail)
+            else 1
+        )
+        reshaped = x.view(batch_size, prefix, n)
+        avg_block = torch.full((n, n), 1.0 / n, dtype=torch.float64)
+
+        # Step 1: z = x − mean
+        mean_broadcast = reshaped.matmul(avg_block)
+        z = reshaped.sub(mean_broadcast)
+
+        # Step 2: v = sqrt(λ · Σ z²)
+        z_sq = z.square().rescale()
+        var_broadcast = z_sq.matmul(avg_block)  # average → broadcast
+        # var_broadcast holds (1/n)·Σz² in each slot; we need λ·Σz² = λ·n·var
+        lam_sum = var_broadcast.mul(lam * n).rescale()
+        v = self._taylor_sqrt(lam_sum)
+
+        # Step 3: y = γ·z·sqrt(nλ) + β·v
+        term1 = z.mul(gamma_sqrt_nl).rescale()
+        term2 = v.mul(beta_flat).rescale()
+        result = term1.add(term2).view(*x.shape)
+
+        # σ = v / √(nλ)  — see _forward_single for derivation
+        sigma = v.mul(1.0 / math.sqrt(n * lam)).rescale()
+        result._sigma_factor = sigma
+        return result
+
+    # ------------------------------------------------------------------ #
+    #  sqrt via 2nd-order Taylor (STIP Algorithm 12)
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _taylor_sqrt(x: "EncryptedTensor") -> "EncryptedTensor":
+        """Approximate sqrt(x) for x ∈ (0, 2) using Taylor expansion.
+
+        sqrt(x) ≈ 1 + 0.5·(x−1) − 0.125·(x−1)²
+
+        Depth cost: 2 levels (one square, one rescale+combine).
+        """
+        t = x.sub(1.0)                       # t = x − 1
+        t1 = t.mul(0.5).rescale()             # 0.5·t
+        t_sq = t.square().rescale()            # t²
+        t2 = t_sq.mul(0.125).rescale()         # 0.125·t²
+        result = t1.sub(t2).add(1.0)           # 1 + 0.5t − 0.125t²
+        return result
+
+    # ------------------------------------------------------------------ #
+
+    def mult_depth(self) -> int:
+        """Estimated multiplicative depth: 5 levels."""
+        return 5
+
+    @classmethod
+    def from_torch(cls, module: torch.nn.LayerNorm, lam: float = 0.01) -> "EncryptedInverseFreeLayerNorm":
+        """Create from a PyTorch LayerNorm layer."""
+        normalized_shape_list: List[int] = list(module.normalized_shape)  # pyright: ignore[reportAssignmentType,reportArgumentType]
+        return cls(
+            normalized_shape=normalized_shape_list,
+            weight=module.weight.data if module.weight is not None else None,  # pyright: ignore[reportUnnecessaryComparison]
+            bias=module.bias.data if module.bias is not None else None,  # pyright: ignore[reportUnnecessaryComparison]
+            eps=module.eps,
+            lam=lam,
+        )
+
+    def extra_repr(self) -> str:
+        return f"normalized_shape={self.normalized_shape}, eps={self.eps}, lam={self.lam}, inverse_free=True"

--- a/cukks/nn/layernorm.py
+++ b/cukks/nn/layernorm.py
@@ -120,7 +120,9 @@ class EncryptedLayerNorm(EncryptedModule):
             normalized = centered.mul(inv_std).rescale()
             output = normalized.mul(self.weight.reshape(-1).tolist()).rescale()
             output = output.add(self.bias.reshape(-1).tolist())
-            return output.view(*x.shape)
+            result = output.view(*x.shape)
+            result._sigma_factor = None
+            return result
         
         # Step 1: Compute mean via sum_and_broadcast
         # sum_and_broadcast(n) sums first n slots and replicates to all n positions
@@ -155,7 +157,7 @@ class EncryptedLayerNorm(EncryptedModule):
         # self.weight is a torch.Tensor (plaintext), self.bias is a torch.Tensor (plaintext)
         output = normalized.mul(self.weight).rescale()
         output = output.add(self.bias)
-        
+        output._sigma_factor = None
         return output
     
     def mult_depth(self) -> int:

--- a/cukks/nn/linear.py
+++ b/cukks/nn/linear.py
@@ -89,6 +89,22 @@ class EncryptedLinear(EncryptedModule):
         """
         if getattr(self, '_sparse_input', False):
             return self._forward_sparse(x)
+
+        sigma = getattr(x, '_sigma_factor', None)
+        if sigma is not None and self.bias is not None:
+            result = x.matmul(self.weight, None,
+                              weight_list=self._weight_list,
+                              bias_list=None,
+                              weight_hash=self._weight_hash,
+                              diag_nonzero=self._diag_nonzero)
+            bias_vec = self.bias.reshape(-1).tolist()
+            padded_bias = bias_vec + [0.0] * (sigma.size - len(bias_vec))
+            bias_scaled = sigma.mul(padded_bias).rescale()
+            bias_scaled._shape = result._shape
+            result = result.add(bias_scaled)
+            result._sigma_factor = sigma
+            return result
+
         return x.matmul(self.weight, self.bias,
                         weight_list=self._weight_list,
                         bias_list=self._bias_list,

--- a/cukks/tensor.py
+++ b/cukks/tensor.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Un
 import torch
 
 if TYPE_CHECKING:
+    from .batching import PackingLayout
     from .context import CKKSInferenceContext
 
 
@@ -88,6 +89,9 @@ class EncryptedTensor:
         self._slots_per_sample: Optional[int] = None
         self._packed_sample_shape: Optional[Tuple[int, ...]] = None
         self._needs_rescale: bool = False  # Lazy rescale flag
+        self._packing_layout: Optional["PackingLayout"] = None
+        self._stip_layout_fresh: bool = False
+        self._sigma_factor: Optional["EncryptedTensor"] = None
 
     def _copy_runtime_metadata_from(self, other: "EncryptedTensor") -> None:
         self._original_size = other._original_size
@@ -97,6 +101,8 @@ class EncryptedTensor:
         self._batch_size = other._batch_size
         self._slots_per_sample = other._slots_per_sample
         self._packed_sample_shape = other._packed_sample_shape
+        self._packing_layout = other._packing_layout
+        self._sigma_factor = other._sigma_factor
 
     def _active_size(self) -> int:
         if self._cnn_layout is not None:
@@ -186,6 +192,8 @@ class EncryptedTensor:
             result._packed_sample_shape = self._packed_sample_shape
         if self._cnn_layout is not None:
             result._cnn_layout = copy.deepcopy(self._cnn_layout)
+        result._packing_layout = self._packing_layout
+        result._sigma_factor = self._sigma_factor
         return result
     @property
     def shape(self) -> Tuple[int, ...]:
@@ -505,12 +513,63 @@ class EncryptedTensor:
         result._needs_rescale = self._needs_rescale
         result._copy_runtime_metadata_from(self)
         return result
-    
+
+    def packed_self_attention_power(
+        self,
+        key: "EncryptedTensor",
+        value: "EncryptedTensor",
+        *,
+        batch_size: int,
+        seq_len: int,
+        embed_dim: int,
+        scale: float,
+        shift: float,
+        reciprocal_coeffs: Sequence[float],
+        renorm_reciprocal_coeffs: Sequence[float],
+    ) -> "EncryptedTensor":
+        new_cipher = self._cipher.packed_self_attention_power(
+            key._cipher,
+            value._cipher,
+            batch_size=int(batch_size),
+            seq_len=int(seq_len),
+            embed_dim=int(embed_dim),
+            scale=float(scale),
+            shift=float(shift),
+            reciprocal_coeffs=list(reciprocal_coeffs),
+            renorm_reciprocal_coeffs=list(renorm_reciprocal_coeffs),
+        )
+        result = EncryptedTensor(new_cipher, self._shape, self._context, self._depth)
+        result._needs_rescale = True
+        result._copy_runtime_metadata_from(self)
+        return result
+
     def conjugate(self) -> "EncryptedTensor":
         """Apply complex conjugation to slots."""
         new_cipher = self._cipher.conjugate()
         result = EncryptedTensor(new_cipher, self._shape, self._context, self._depth)
         result._needs_rescale = self._needs_rescale
+        result._copy_runtime_metadata_from(self)
+        return result
+
+    def mul_by_i(self) -> "EncryptedTensor":
+        """Multiply all slots by the imaginary unit i (for RIHP packing)."""
+        new_cipher = self._cipher.mul_by_i()
+        result = EncryptedTensor(new_cipher, self._shape, self._context, self._depth)
+        result._needs_rescale = self._needs_rescale
+        result._copy_runtime_metadata_from(self)
+        return result
+
+    def extract_real(self) -> "EncryptedTensor":
+        """Extract the real part of all slots."""
+        new_cipher = self._cipher.extract_real()
+        result = EncryptedTensor(new_cipher, self._shape, self._context, self._depth)
+        result._copy_runtime_metadata_from(self)
+        return result
+
+    def extract_imag(self) -> "EncryptedTensor":
+        """Extract the imaginary part of all slots as real-valued."""
+        new_cipher = self._cipher.extract_imag()
+        result = EncryptedTensor(new_cipher, self._shape, self._context, self._depth)
         result._copy_runtime_metadata_from(self)
         return result
     
@@ -1191,6 +1250,7 @@ class EncryptedTensor:
         result = EncryptedTensor(self._cipher, self._shape, self._context, self._depth)
         result._needs_rescale = self._needs_rescale
         result._copy_runtime_metadata_from(self)
+        result._stip_layout_fresh = self._stip_layout_fresh
         return result
     
     def __repr__(self) -> str:

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,7 @@ Use this page as the main index for project documentation.
 - [API Reference](api.md)
 - [CKKS Concepts](concepts.md)
 - [GPU Acceleration](gpu-acceleration.md)
+- [STIP Packed Attention](stip-attention.md)
 - [Examples Overview](examples/README.md)
 
 ## Contribution and release operations

--- a/docs/api.md
+++ b/docs/api.md
@@ -932,11 +932,11 @@ attention = EncryptedApproxAttention.from_torch(
 
 **Methods:**
 
-- `forward(x)`: Self-attention — uses `x` as query, key, and value. Supports seq_len=1 only in pure HE mode.
-- `forward_attention(query, key, value)`: Full attention with separate Q, K, V inputs. Supports seq_len=1 only in pure HE mode.
+- `forward(x)`: Self-attention — uses `x` as query, key, and value. Supports single encrypted tensors with `seq_len=1`, or packed encrypted batches with sample shape `(seq_len, embed_dim)` for `seq_len <= 8`.
+- `forward_attention(query, key, value)`: Full attention with separate Q, K, V inputs. Supports single encrypted tensors with `seq_len=1`, or per-token `List[EncryptedTensor]` inputs for `seq_len <= 8`.
 - `mult_depth()`: Returns estimated multiplicative depth (includes projections + Q@K^T + softmax polynomial + attn@V + output projection).
 
-**Note:** This is an approximation using cipher-cipher multiplication for Q@K^T and sum_and_broadcast for attention aggregation. Accuracy depends on input range and polynomial degree. Best results when attention scores are normalized to a small range (e.g., [-2, 2]). `from_torch()` extracts Q, K, V, and output projection weights from `nn.MultiheadAttention`. Limited to seq_len=1 in pure HE mode.
+**Note:** This is an approximation using cipher-cipher multiplication for Q@K^T and sum_and_broadcast for attention aggregation. Accuracy depends on input range and polynomial degree. Best results when attention scores are normalized to a small range (e.g., [-2, 2]). `from_torch()` extracts Q, K, V, and output projection weights from `nn.MultiheadAttention`. Single-tensor inputs are limited to `seq_len=1`; multi-token support is available through packed encrypted batches in `forward()` or `List[EncryptedTensor]` inputs in `forward_attention()`, with a maximum `seq_len` of 8.
 
 ---
 

--- a/docs/stip-attention.md
+++ b/docs/stip-attention.md
@@ -1,0 +1,232 @@
+# STIP: Packed Attention for CKKS
+
+This document describes the STIP (Secure Transformer Inference Protocol) implementation in CuKKS, including packing algorithms, inverse-free LayerNorm, and practical layer limits.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Packing Approaches](#packing-approaches)
+- [Implemented Algorithms](#implemented-algorithms)
+- [Practical Attention Layer Limits](#practical-attention-layer-limits)
+- [Configuration Guide](#configuration-guide)
+- [Current Status](#current-status)
+
+---
+
+## Overview
+
+CuKKS supports two data packing strategies for encrypted inference:
+
+| Strategy | Slot Layout | Best For |
+|----------|------------|----------|
+| **Row packing** (default) | `CT[i] = token[i]` full hidden vector | CNN, MLP, short sequences, batch inference |
+| **Column packing** (STIP) | `CT[j] = feature[j]` across all tokens | Long-sequence Transformers, rotation reduction |
+
+Both paths are fully supported. The converter auto-detects which LayerNorm variant to use based on the model's activation functions.
+
+## Packing Approaches
+
+### Row Packing (Default)
+
+Each ciphertext holds one token's complete hidden vector:
+
+```
+CT₀ = [token₀_feat₀, token₀_feat₁, ..., token₀_feat_d]
+CT₁ = [token₁_feat₀, token₁_feat₁, ..., token₁_feat_d]
+```
+
+- Matrix multiplication via BSGS diagonal method: **O(2√d) rotations**
+- Batch SIMD: pack N samples into one ciphertext
+- QK^T requires cross-token rotations: **O(seq_len) rotations**
+
+### Column Packing (STIP)
+
+Each ciphertext holds one feature dimension across all tokens:
+
+```
+CT₀ = [token₀_feat₀, token₁_feat₀, ..., token_n_feat₀]
+CT₁ = [token₀_feat₁, token₁_feat₁, ..., token_n_feat₁]
+```
+
+- Matrix multiplication via element-wise multiply + sum: **0 rotations**
+- QK^T via RIHP halved inner product: **O(seq_len/2) rotations**
+- Complex-slot utilization: RIHP packs 2 diagonals per ciphertext, DHP processes 2 heads simultaneously
+
+## Implemented Algorithms
+
+### RIHP (Real-Imaginary Hybrid Packing)
+
+Packs two diagonals into one ciphertext using complex slots:
+
+```
+k_hybrid[j] = k[j] + i · RotL(k[j], m/2)
+```
+
+- Halves the number of ciphertexts needed for CCMM
+- Unpacking: `P[r] = Re(C[r])`, `P[r+m/2] = Im(C[r])`
+- Module: `cukks.batching.RIHPacker`
+
+### DHP (Dual-Head Packing)
+
+Packs adjacent attention heads into complex slots:
+
+```
+W̃ = W[h] + i·W[h+1]
+```
+
+- One PCMM processes two heads simultaneously
+- After attention: repack for output projection
+- Module: `cukks.batching.DHPacker`
+
+### AMCP (Adaptive Multi-Column Packing)
+
+Packs k feature columns into one ciphertext with interleaved batching:
+
+```
+k = max{κ ∈ Divisors(H) | κ·t·m ≤ S}
+```
+
+- Reduces ciphertext count by factor k
+- Uses iterative group-wise rotation for alignment
+- Module: `cukks.batching.AMCPacker`
+
+### Inverse-Free LayerNorm
+
+For models with homogeneous activations (ReLU), uses a depth-efficient LN:
+
+```
+ŷ_i = γ · z_i · √(nλ) + β · v    where v = √(λ · Σz_i²)
+```
+
+- **5 multiplicative levels** (vs 18 for standard LN)
+- σ propagation through subsequent layers enables bias scaling
+- Auto-detected via `torch.fx` graph tracing at conversion time
+- Module: `cukks.nn.EncryptedInverseFreeLayerNorm`
+
+**Eligibility**: A LayerNorm qualifies for inverse-free mode when the path to the next LayerNorm contains only linear operations and homogeneous activations (ReLU, Dropout, Identity). Non-homogeneous activations (GELU, SiLU, Sigmoid, Tanh) trigger fallback to standard LN.
+
+## Practical Attention Layer Limits
+
+> **Key insight**: Multiplicative depth is NOT the limiting factor — bootstrapping solves depth. **Precision (approximation error accumulation) is the real bottleneck.**
+
+### Error Sources Per Block
+
+| Component | Error Type | Magnitude |
+|-----------|-----------|-----------|
+| ReLU degree-4 | Absolute | ~0.23 |
+| ReLU degree-8 | Absolute | ~0.13 |
+| GELU degree-4 | Absolute | ~5×10⁻⁴ |
+| GELU degree-8 | Absolute | ~2×10⁻⁴ |
+| Softmax 1/x (degree-15) | Relative | ~6×10⁻¹⁰ |
+| Inv-Free LN Taylor √ | Relative | ~10⁻³ |
+| Standard LN 1/√x (degree-15) | Relative | ~0.28 (self-correcting) |
+
+### Practical Layer Limits (cosine similarity > 0.99)
+
+| Configuration | Activation | LayerNorm | Levels/Block | Practical Layers | Dominant Error |
+|--------------|-----------|-----------|-------------|-----------------|----------------|
+| ReLU deg-4 | `EncryptedReLU(degree=4)` | Inverse-Free (auto) | ~15 | **2–3** | ReLU approximation |
+| ReLU deg-8 | `EncryptedReLU(degree=8)` | Inverse-Free (auto) | ~18 | **8–10** | ReLU approximation |
+| GELU deg-4 | `EncryptedGELU(degree=4)` | Standard (auto) | ~28 | **12+** | Accumulated rounding |
+| GELU deg-8 | `EncryptedGELU(degree=8)` | Standard (auto) | ~31 | **20+** | Accumulated rounding |
+
+### Why ReLU Limits Are Lower
+
+ReLU has a sharp kink at x=0 that polynomial approximation cannot capture well:
+- Degree-4: large absolute error (~0.23) near the kink
+- Degree-8: better but still ~0.13
+- Error compounds multiplicatively through layers
+
+GELU is inherently smooth, making polynomial approximation much more accurate (~5×10⁻⁴ even at degree-4).
+
+### Recommendations
+
+| Model Type | Recommended Config | Expected Layers |
+|-----------|-------------------|----------------|
+| Lightweight / edge | ReLU deg-8 | Up to 8 layers |
+| BERT-base / GPT-small | GELU deg-4 | 12 layers |
+| Large Transformers | GELU deg-8 | 20+ layers |
+
+## Configuration Guide
+
+### Basic Usage (Auto-Detection)
+
+```python
+import cukks
+
+# GELU model → Standard LN auto-selected
+model = MyGELUTransformer()
+enc_model, ctx = cukks.convert(model, activation_degree=4)
+
+# ReLU model → Inverse-Free LN auto-selected
+model = MyReLUTransformer()
+enc_model, ctx = cukks.convert(model, activation_degree=8)
+```
+
+### Column-Wise Attention (STIP Path)
+
+```python
+from cukks.batching import RIHPacker, DHPacker, AMCPacker
+
+# RIHP: halved rotation count for attention
+rihp = RIHPacker(half_seq_len=seq_len // 2)
+
+# DHP: process 2 heads simultaneously
+dhp = DHPacker(head_dim=64, num_heads=8)
+
+# AMCP: pack multiple columns into one ciphertext
+amcp = AMCPacker(
+    num_slots=16384,
+    seq_len=seq_len,
+    hidden_dim=768,
+    batch_size=1,
+)
+```
+
+### Depth Budget Planning
+
+```
+Per Transformer block:
+  QKV projection:        1 level  (matmul)
+  Attention scores:      1 level  (Q·K^T)
+  Softmax:              10 levels (degree-15 polynomial)
+  Value weighting:       1 level  (weights·V)
+  Output projection:     1 level  (matmul)
+  FFN (2 Linear):        2 levels (matmul × 2)
+  Activation:           2-4 levels (degree 4-8)
+  LayerNorm (×2):       10-36 levels (standard) or 4-10 levels (inv-free)
+  ─────────────────────
+  Total:               ~15-31 levels per block (bootstrapping resets)
+```
+
+## Current Status
+
+### Implemented ✅
+
+| Component | Module | Tests |
+|-----------|--------|-------|
+| RIHP packer | `cukks.batching.RIHPacker` | 4 |
+| DHP packer | `cukks.batching.DHPacker` | 7 |
+| AMCP packer | `cukks.batching.AMCPacker` | 15 |
+| Inverse-Free LN | `cukks.nn.EncryptedInverseFreeLayerNorm` | 33 |
+| σ propagation (bias scaling) | `cukks.nn.EncryptedLinear` | 7 |
+| Complex-slot ops | `cukks.tensor.EncryptedTensor` | — |
+| Column-wise attention | `cukks.nn.EncryptedApproxAttention` | 7 |
+| torch.fx LN detection | `cukks.analysis.inverse_free_detect` | — |
+| **Total** | | **531 tests passing** |
+
+### Planned Enhancements
+
+| Enhancement | Impact | Status |
+|------------|--------|--------|
+| Hoisted automorphisms (BSGS) | 30–75× rotation speedup | Not started |
+| GK constant normalization | Remove softmax 1/x error source | Not started |
+| Composite polynomial ReLU | Extend ReLU model layer limit | Not started |
+| AMCP → column-wise attention wiring | Reduce ciphertext count | Not started |
+| Lazy rescaling in BSGS | Save 1 level per matmul | Not started |
+
+## References
+
+- Choi, H. et al. — STIP: Secure Transformer Inference Protocol (RIHP, DHP, AMCP algorithms)
+- Halevi, S. & Shoup, V. — Faster Homomorphic Linear Transformations in HElib (BSGS, 2018)
+- Bossuat, J.-P. et al. — Efficient Bootstrapping for Approximate HE (Double-hoisting, BMPH21)

--- a/tests/mocks/mock_backend.py
+++ b/tests/mocks/mock_backend.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Iterable, Sequence
+from typing import TYPE_CHECKING, Iterable, Sequence, cast
 
 import torch
 
@@ -85,7 +85,8 @@ class MockCKKSContext:
         """Unwrap a MockCKKSTensor back to a regular tensor."""
         final_shape = shape or tensor.shape
         num_elements = int(math.prod(final_shape)) if final_shape else tensor.size
-        values = tensor.data[:num_elements].clone()
+        raw = tensor.data[:num_elements].clone()
+        values = raw.real.to(torch.float64) if raw.is_complex() else raw
         target_device = (
             torch.device(device)
             if device is not None
@@ -113,7 +114,10 @@ class MockCKKSTensor:
         depth: int = 0,
     ):
         self.context = context
-        self.data = data.to(dtype=torch.float64)
+        if data.is_complex():
+            self.data = data.to(dtype=torch.complex128)
+        else:
+            self.data = data.to(dtype=torch.float64)
         self.shape = tuple(shape)
         self.device = torch.device(device) if isinstance(device, str) else device
         self.size = int(math.prod(self.shape)) if len(self.shape) > 0 else 1
@@ -222,8 +226,29 @@ class MockCKKSTensor:
         return result
 
     def conjugate(self) -> "MockCKKSTensor":
-        """Complex conjugate (identity for real values)."""
-        result = MockCKKSTensor(self.context, self.data.clone(), self.shape, self.device, self._depth)
+        """Complex conjugate of slot values."""
+        result = MockCKKSTensor(self.context, self.data.conj().resolve_conj(), self.shape, self.device, self._depth)
+        result._level = self._level
+        return result
+
+    def mul_by_i(self) -> "MockCKKSTensor":
+        """Multiply all slots by the imaginary unit i."""
+        cdata = self.data.to(torch.complex128) * 1j
+        result = MockCKKSTensor(self.context, cdata, self.shape, self.device, self._depth)
+        result._level = self._level
+        return result
+
+    def extract_real(self) -> "MockCKKSTensor":
+        """Extract real part of all slots: Re(ct) = 0.5*(ct + Conj(ct))."""
+        real_part = self.data.real if self.data.is_complex() else self.data.clone()
+        result = MockCKKSTensor(self.context, real_part.to(torch.float64), self.shape, self.device, self._depth)
+        result._level = self._level
+        return result
+
+    def extract_imag(self) -> "MockCKKSTensor":
+        """Extract imaginary part of all slots as a real-valued tensor."""
+        imag_part = self.data.imag if self.data.is_complex() else torch.zeros_like(self.data)
+        result = MockCKKSTensor(self.context, imag_part.to(torch.float64), self.shape, self.device, self._depth)
         result._level = self._level
         return result
 
@@ -232,6 +257,9 @@ class MockCKKSTensor:
         result = MockCKKSTensor(self.context, self.data.clone(), self.shape, self.device, self._depth)
         result._level = max(0, self._level - 1)
         return result
+
+    def _ensure_rescaled(self) -> "MockCKKSTensor":
+        return self
 
     def matmul_dense(
         self, matrix: Sequence[Sequence[float]] | torch.Tensor
@@ -267,7 +295,7 @@ class MockCKKSTensor:
         bsgs_n2: int = 0,
         weight_hash: int = 0,
         diag_nonzero: Sequence[bool] | None = None,
-    ) -> "MockCKKSTensor":
+        ) -> "MockCKKSTensor":
         """BSGS matrix-vector multiplication (mock delegates to dense).
 
         In the real backend, BSGS reduces rotation count from O(n) to O(sqrt(n)).
@@ -275,6 +303,61 @@ class MockCKKSTensor:
         ``matmul_dense`` while accepting the extra parameters silently.
         """
         return self.matmul_dense(matrix)
+
+    def packed_self_attention_power(
+        self,
+        key: "MockCKKSTensor",
+        value: "MockCKKSTensor",
+        batch_size: int,
+        seq_len: int,
+        embed_dim: int,
+        scale: float,
+        shift: float,
+        reciprocal_coeffs: Sequence[float],
+        renorm_reciprocal_coeffs: Sequence[float],
+    ) -> "MockCKKSTensor":
+        from cukks.nn import EncryptedApproxAttention
+
+        slots_per_sample = seq_len * embed_dim
+        outputs = torch.zeros_like(self.data)
+        attn = EncryptedApproxAttention(embed_dim=embed_dim, num_heads=1)
+        attn.scale = scale
+
+        for batch_idx in range(batch_size):
+            sample_start = batch_idx * slots_per_sample
+            sample_end = sample_start + slots_per_sample
+            q_sample = self.data[sample_start:sample_end].view(seq_len, embed_dim)
+            k_sample = key.data[sample_start:sample_end].view(seq_len, embed_dim)
+            v_sample = value.data[sample_start:sample_end].view(seq_len, embed_dim)
+            output_sample = torch.zeros_like(q_sample)
+
+            q_tokens = [self._token_tensor(q_sample[i], embed_dim) for i in range(seq_len)]
+            k_tokens = [self._token_tensor(k_sample[i], embed_dim) for i in range(seq_len)]
+            v_tokens = [self._token_tensor(v_sample[i], embed_dim) for i in range(seq_len)]
+
+            token_outputs = cast(
+                list[MockCKKSTensor],
+                attn.forward_attention(
+                    cast(list, q_tokens),
+                    cast(list, k_tokens),
+                    cast(list, v_tokens),
+                ),
+            )
+            for query_index, token_output in enumerate(token_outputs):
+                output_sample[query_index] = token_output.data[:embed_dim]
+
+            outputs[sample_start:sample_end] = output_sample.reshape(-1)
+
+        result = MockCKKSTensor(self.context, outputs, self.shape, self.device, self._depth + 8)
+        result._level = max(0, min(self._level, key._level, value._level) - 8)
+        return result
+
+    def _token_tensor(self, values: torch.Tensor, size: int) -> "MockCKKSTensor":
+        padded = torch.zeros_like(self.data)
+        padded[:size] = values.to(dtype=torch.float64)
+        tensor = MockCKKSTensor(self.context, padded, (size,), self.device, self._depth)
+        tensor._level = self._level
+        return tensor
 
     def poly_eval(self, coeffs: Sequence[float]) -> "MockCKKSTensor":
         """Evaluate a polynomial on the encrypted data.

--- a/tests/test_amcp.py
+++ b/tests/test_amcp.py
@@ -1,0 +1,154 @@
+import pytest
+import torch
+
+
+def _patch_mock_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tests.mocks.mock_backend import MockCKKSConfig, MockCKKSContext
+    import cukks.context as ctx_module
+
+    monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+    monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+    monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+
+def _mock_ctx(monkeypatch: pytest.MonkeyPatch):
+    from cukks import CKKSInferenceContext
+
+    _patch_mock_backend(monkeypatch)
+    return CKKSInferenceContext(device="cpu", use_bsgs=False)
+
+
+def test_compute_packing_factor_basic():
+    import cukks.batching as batching_module
+
+    k = batching_module.AMCPacker.compute_packing_factor(
+        num_heads=4,
+        seq_len=8,
+        batch_size=2,
+        total_slots=64,
+    )
+    assert k == 4
+
+
+def test_compute_packing_factor_constrained():
+    import cukks.batching as batching_module
+
+    k = batching_module.AMCPacker.compute_packing_factor(
+        num_heads=8,
+        seq_len=16,
+        batch_size=4,
+        total_slots=128,
+    )
+    assert k == 2
+
+
+def test_compute_packing_factor_no_valid():
+    import cukks.batching as batching_module
+
+    with pytest.raises(ValueError, match="No valid AMCP packing factor"):
+        batching_module.AMCPacker.compute_packing_factor(
+            num_heads=4,
+            seq_len=8,
+            batch_size=2,
+            total_slots=7,
+        )
+
+
+def test_build_masks_structure():
+    import cukks.batching as batching_module
+
+    packer = batching_module.AMCPacker(
+        num_heads=8,
+        seq_len=4,
+        batch_size=2,
+        total_slots=24,
+    )
+    assert packer.k == 2
+    assert packer.stride == 6
+    assert packer.width == 4
+
+    u_mask, v_mask = packer.build_masks()
+    expected_u_block = [1.0, 1.0, 0.0, 0.0, 0.0, 0.0]
+    expected_v_block = [0.0, 0.0, 1.0, 1.0, 0.0, 0.0]
+
+    assert len(u_mask) == packer.total_slots
+    assert len(v_mask) == packer.total_slots
+    assert u_mask == expected_u_block * packer.seq_len
+    assert v_mask == expected_v_block * packer.seq_len
+
+
+def test_group_wise_rotation_count(monkeypatch: pytest.MonkeyPatch):
+    import cukks.batching as batching_module
+
+    ctx = _mock_ctx(monkeypatch)
+    packer = batching_module.AMCPacker(
+        num_heads=8,
+        seq_len=4,
+        batch_size=2,
+        total_slots=24,
+    )
+    data = torch.arange(packer.total_slots, dtype=torch.float64)
+    ct = ctx.encrypt(data)
+
+    aligned = packer.group_wise_rotation(ct, ctx)
+
+    assert len(aligned) == packer.k
+
+
+def test_group_wise_rotation_values(monkeypatch: pytest.MonkeyPatch):
+    import cukks.batching as batching_module
+
+    ctx = _mock_ctx(monkeypatch)
+    packer = batching_module.AMCPacker(
+        num_heads=2,
+        seq_len=1,
+        batch_size=2,
+        total_slots=8,
+    )
+    data = torch.tensor([1.0, 2.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0], dtype=torch.float64)
+    ct = ctx.encrypt(data)
+
+    aligned = packer.group_wise_rotation(ct, ctx)
+
+    expected_states = [
+        torch.tensor([1.0, 2.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0], dtype=torch.float64),
+        torch.tensor([3.0, 4.0, 1.0, 2.0, 0.0, 0.0, 0.0, 0.0], dtype=torch.float64),
+    ]
+
+    assert len(aligned) == len(expected_states)
+    for idx, expected in enumerate(expected_states):
+        actual = ctx.decrypt(aligned[idx], shape=(8,)).to(torch.float64)
+        torch.testing.assert_close(actual, expected, rtol=1e-6, atol=1e-6)
+
+
+def test_scale_rotation():
+    import cukks.batching as batching_module
+
+    packer = batching_module.AMCPacker(
+        num_heads=8,
+        seq_len=16,
+        batch_size=4,
+        total_slots=128,
+    )
+    assert packer.scale_rotation(3) == 24
+    assert packer.scale_rotation(-2) == -16
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"num_heads": 0, "seq_len": 8, "batch_size": 2, "total_slots": 64},
+        {"num_heads": 4, "seq_len": 0, "batch_size": 2, "total_slots": 64},
+        {"num_heads": 4, "seq_len": 8, "batch_size": 0, "total_slots": 64},
+        {"num_heads": 4, "seq_len": 8, "batch_size": 2, "total_slots": 0},
+        {"num_heads": -1, "seq_len": 8, "batch_size": 2, "total_slots": 64},
+        {"num_heads": 4, "seq_len": -1, "batch_size": 2, "total_slots": 64},
+        {"num_heads": 4, "seq_len": 8, "batch_size": -1, "total_slots": 64},
+        {"num_heads": 4, "seq_len": 8, "batch_size": 2, "total_slots": -1},
+    ],
+)
+def test_invalid_params(kwargs: dict[str, int]):
+    import cukks.batching as batching_module
+
+    with pytest.raises(ValueError):
+        batching_module.AMCPacker(**kwargs)

--- a/tests/test_batching.py
+++ b/tests/test_batching.py
@@ -128,6 +128,112 @@ class TestSlotPacker:
             packer.unpack(packed, num_samples=0)
 
 
+class TestPackingLayout:
+
+    def test_layout_creation(self):
+        from cukks.batching import PackingLayout
+
+        layout = PackingLayout(seq_len=4, d_model=16, num_heads=4, block_size=16)
+
+        assert layout.d_head == 4
+        assert layout.total_slots_needed == 64
+
+    def test_layout_token_offset(self):
+        from cukks.batching import PackingLayout
+
+        layout = PackingLayout(seq_len=4, d_model=16, num_heads=4, block_size=16)
+
+        assert layout.token_offset(0) == 0
+        assert layout.token_offset(1) == 16
+        assert layout.token_offset(3) == 48
+
+    def test_layout_head_range(self):
+        from cukks.batching import PackingLayout
+
+        layout = PackingLayout(seq_len=2, d_model=16, num_heads=4, block_size=16)
+
+        assert layout.head_range(0) == (0, 4)
+        assert layout.head_range(3) == (12, 16)
+
+    def test_layout_validation(self):
+        from cukks.batching import PackingLayout
+
+        with pytest.raises(ValueError, match="divisible"):
+            PackingLayout(seq_len=4, d_model=15, num_heads=4, block_size=16)
+        with pytest.raises(ValueError, match="block_size"):
+            PackingLayout(seq_len=4, d_model=16, num_heads=4, block_size=8)
+        with pytest.raises(ValueError, match="seq_len"):
+            PackingLayout(seq_len=0, d_model=16, num_heads=4, block_size=16)
+
+    def test_layout_complex_packing_default(self):
+        from cukks.batching import PackingLayout
+
+        layout = PackingLayout(seq_len=4, d_model=16, num_heads=4, block_size=16)
+
+        assert layout.complex_packing == "real_only"
+
+
+class TestTokenBlockPacker:
+
+    def test_pack_unpack_roundtrip(self):
+        from cukks.batching import PackingLayout, TokenBlockPacker
+
+        layout = PackingLayout(seq_len=4, d_model=16, num_heads=4, block_size=16)
+        packer = TokenBlockPacker(layout, total_slots=128)
+        source = torch.arange(64, dtype=torch.float64).reshape(4, 16)
+
+        packed = packer.pack(source)
+        recovered = packer.unpack(packed)
+
+        assert packed.shape == (128,)
+        torch.testing.assert_close(recovered, source)
+
+    def test_pack_token_positions(self):
+        from cukks.batching import PackingLayout, TokenBlockPacker
+
+        layout = PackingLayout(seq_len=2, d_model=4, num_heads=2, block_size=4)
+        packer = TokenBlockPacker(layout, total_slots=16)
+        source = torch.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+
+        packed = packer.pack(source)
+
+        torch.testing.assert_close(packed[:8], torch.tensor([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], dtype=torch.float64))
+
+    def test_pack_block_padding(self):
+        from cukks.batching import PackingLayout, TokenBlockPacker
+
+        layout = PackingLayout(seq_len=2, d_model=4, num_heads=2, block_size=8)
+        packer = TokenBlockPacker(layout, total_slots=24)
+        source = torch.tensor([[1.0, 2.0, 3.0, 4.0], [5.0, 6.0, 7.0, 8.0]])
+
+        packed = packer.pack(source)
+
+        torch.testing.assert_close(
+            packed[:16],
+            torch.tensor([1.0, 2.0, 3.0, 4.0, 0.0, 0.0, 0.0, 0.0, 5.0, 6.0, 7.0, 8.0, 0.0, 0.0, 0.0, 0.0], dtype=torch.float64),
+        )
+
+    def test_head_masks_cover_active_region(self):
+        from cukks.batching import PackingLayout, TokenBlockPacker
+
+        layout = PackingLayout(seq_len=2, d_model=16, num_heads=4, block_size=16)
+        packer = TokenBlockPacker(layout, total_slots=64)
+
+        masks = packer.all_head_masks()
+        mask_sum = [sum(mask[idx] for mask in masks) for idx in range(layout.total_slots_needed)]
+
+        assert all(value == 1.0 for value in mask_sum)
+
+    def test_non_real_packing_not_implemented(self):
+        from cukks.batching import PackingLayout, TokenBlockPacker
+
+        layout = PackingLayout(seq_len=2, d_model=4, num_heads=2, block_size=4, complex_packing="rihp")
+        packer = TokenBlockPacker(layout, total_slots=16)
+
+        with pytest.raises(NotImplementedError, match="rihp"):
+            packer.pack(torch.ones(2, 4))
+
+
 class TestEncryptDecryptBatch:
 
     def test_encrypt_decrypt_batch_basic(self, mock_enc_context: Any):
@@ -190,6 +296,42 @@ class TestContextBatchMethods:
         assert getattr(enc_batch, "_packed_batch", False) is True
         assert getattr(enc_batch, "_batch_size", None) == 2
         assert getattr(enc_batch, "_slots_per_sample", None) == 3
+
+    def test_context_encrypt_decrypt_sequence(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+        from tests.mocks.mock_backend import MockCKKSContext, MockCKKSConfig
+        import cukks.context as ctx_module
+
+        monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+        monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+        monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False)
+        source = torch.arange(64, dtype=torch.float64).reshape(4, 16)
+
+        enc = ctx.encrypt_sequence(source, num_heads=4)
+        recovered = ctx.decrypt_sequence(enc)
+
+        assert enc.shape == (4, 16)
+        assert getattr(enc, "_packing_layout", None) is not None
+        torch.testing.assert_close(recovered, source.to(torch.float32), rtol=1e-4, atol=1e-4)
+
+    def test_context_encrypt_sequence_validation(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+        from tests.mocks.mock_backend import MockCKKSContext, MockCKKSConfig
+        import cukks.context as ctx_module
+
+        monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+        monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+        monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False)
+
+        with pytest.raises(ValueError, match="Expected 2D tensor"):
+            ctx.encrypt_sequence(torch.arange(8.0), num_heads=2)
+
+        with pytest.raises(ValueError, match="requires"):
+            ctx.encrypt_sequence(torch.ones(2000, 16), num_heads=4)
 
     def test_context_encrypt_batch_forward_with_identity(self, monkeypatch: pytest.MonkeyPatch):
         from cukks import CKKSInferenceContext
@@ -728,7 +870,12 @@ class TestPackedBatchNativeExecution:
         torch.testing.assert_close(recovered[0], expected[0], rtol=1e-4, atol=1e-4)
         torch.testing.assert_close(recovered[1], expected[1], rtol=1e-4, atol=1e-4)
 
-    def test_attention_supports_packed_multi_token_batch(self, monkeypatch: pytest.MonkeyPatch):
+    @pytest.mark.parametrize("normalization_mode", ["power_softmax", "gaussian"])
+    def test_attention_supports_packed_multi_token_batch(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        normalization_mode: str,
+    ):
         from cukks import CKKSInferenceContext
         from cukks.nn import EncryptedApproxAttention
         from tests.mocks.mock_backend import MockCKKSContext, MockCKKSConfig
@@ -745,7 +892,11 @@ class TestPackedBatchNativeExecution:
         ]
         enc_batch = ctx.encrypt_batch(samples)
 
-        attn = EncryptedApproxAttention(embed_dim=2, num_heads=1)
+        attn = EncryptedApproxAttention(
+            embed_dim=2,
+            num_heads=1,
+            normalization_mode=normalization_mode,
+        )
         enc_output = attn(enc_batch)
         recovered = ctx.decrypt_batch(enc_output, sample_shape=(2, 2))
 
@@ -758,6 +909,155 @@ class TestPackedBatchNativeExecution:
 
         torch.testing.assert_close(recovered[0], expected[0], rtol=1e-4, atol=1e-4)
         torch.testing.assert_close(recovered[1], expected[1], rtol=1e-4, atol=1e-4)
+
+    @pytest.mark.parametrize("seq_len", [2, 4])
+    @pytest.mark.parametrize("normalization_mode", ["power_softmax", "gaussian"])
+    def test_attention_packed_multi_token_reuses_rotations(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        seq_len: int,
+        normalization_mode: str,
+    ):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+        from tests.mocks.mock_backend import MockCKKSContext, MockCKKSConfig, MockCKKSTensor
+        import cukks.context as ctx_module
+
+        monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+        monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+        monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+        rotate_calls = 0
+        original_rotate = MockCKKSTensor.rotate
+
+        def counting_rotate(self: MockCKKSTensor, steps: int) -> MockCKKSTensor:
+            nonlocal rotate_calls
+            rotate_calls += 1
+            return original_rotate(self, steps)
+
+        monkeypatch.setattr(MockCKKSTensor, "rotate", counting_rotate)
+
+        ctx = CKKSInferenceContext(device="cpu")
+        samples = [torch.randn(seq_len, 2) * 0.1, torch.randn(seq_len, 2) * 0.1]
+        enc_batch = ctx.encrypt_batch(samples)
+
+        attn = EncryptedApproxAttention(
+            embed_dim=2,
+            num_heads=1,
+            normalization_mode=normalization_mode,
+        )
+        _ = attn(enc_batch)
+
+        if normalization_mode == "power_softmax":
+            assert rotate_calls == 0
+        else:
+            assert rotate_calls == (2 * seq_len * seq_len) + (4 * (seq_len - 1))
+
+    def test_attention_packed_power_softmax_uses_native_fast_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+        from tests.mocks.mock_backend import MockCKKSContext, MockCKKSConfig, MockCKKSTensor
+        import cukks.context as ctx_module
+
+        monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+        monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+        monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+        native_calls = 0
+        original_native = MockCKKSTensor.packed_self_attention_power
+
+        def counting_native(
+            self: MockCKKSTensor,
+            key: MockCKKSTensor,
+            value: MockCKKSTensor,
+            batch_size: int,
+            seq_len: int,
+            embed_dim: int,
+            scale: float,
+            shift: float,
+            reciprocal_coeffs: list[float],
+            renorm_reciprocal_coeffs: list[float],
+        ) -> MockCKKSTensor:
+            nonlocal native_calls
+            native_calls += 1
+            return original_native(
+                self,
+                key,
+                value,
+                batch_size,
+                seq_len,
+                embed_dim,
+                scale,
+                shift,
+                reciprocal_coeffs,
+                renorm_reciprocal_coeffs,
+            )
+
+        monkeypatch.setattr(MockCKKSTensor, "packed_self_attention_power", counting_native)
+
+        ctx = CKKSInferenceContext(device="cpu")
+        enc_batch = ctx.encrypt_batch([torch.randn(2, 2) * 0.1, torch.randn(2, 2) * 0.1])
+        attn = EncryptedApproxAttention(embed_dim=2, num_heads=1, normalization_mode="power_softmax")
+
+        _ = attn(enc_batch)
+
+        assert native_calls == 1
+
+    def test_attention_packed_gaussian_keeps_python_fallback(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+        from tests.mocks.mock_backend import MockCKKSContext, MockCKKSConfig, MockCKKSTensor
+        import cukks.context as ctx_module
+
+        monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+        monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+        monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+        native_calls = 0
+        original_native = MockCKKSTensor.packed_self_attention_power
+
+        def counting_native(
+            self: MockCKKSTensor,
+            key: MockCKKSTensor,
+            value: MockCKKSTensor,
+            batch_size: int,
+            seq_len: int,
+            embed_dim: int,
+            scale: float,
+            shift: float,
+            reciprocal_coeffs: list[float],
+            renorm_reciprocal_coeffs: list[float],
+        ) -> MockCKKSTensor:
+            nonlocal native_calls
+            native_calls += 1
+            return original_native(
+                self,
+                key,
+                value,
+                batch_size,
+                seq_len,
+                embed_dim,
+                scale,
+                shift,
+                reciprocal_coeffs,
+                renorm_reciprocal_coeffs,
+            )
+
+        monkeypatch.setattr(MockCKKSTensor, "packed_self_attention_power", counting_native)
+
+        ctx = CKKSInferenceContext(device="cpu")
+        enc_batch = ctx.encrypt_batch([torch.randn(2, 2) * 0.1, torch.randn(2, 2) * 0.1])
+        attn = EncryptedApproxAttention(embed_dim=2, num_heads=1, normalization_mode="gaussian")
+
+        _ = attn(enc_batch)
+
+        assert native_calls == 0
 
     def test_conv2d_supports_packed_batch_of_patches(self, monkeypatch: pytest.MonkeyPatch):
         from cukks import CKKSInferenceContext

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -11,6 +11,7 @@ from cukks.converter import (
     convert,
     estimate_depth,
 )
+from cukks.context import CKKSInferenceContext
 from cukks.nn import (
     EncryptedLinear,
     EncryptedSquare,
@@ -114,12 +115,11 @@ class TestModelConverter:
             atol=1e-6,
         )
         
-        if model.bias is not None:
-            assert torch.allclose(
-                enc_model.bias.float(),
-                model.bias.data.float(),
-                atol=1e-6,
-            )
+        assert torch.allclose(
+            enc_model.bias.float(),
+            model.bias.data.float(),
+            atol=1e-6,
+        )
 
 
 class TestConvertFunction:
@@ -136,6 +136,7 @@ class TestConvertFunction:
         assert len(result) == 2
         enc_model, ctx = result
         assert isinstance(enc_model, EncryptedLinear)
+        assert isinstance(ctx, CKKSInferenceContext)
     
     def test_convert_with_options(self):
         """Test convert() with custom options."""
@@ -150,9 +151,35 @@ class TestConvertFunction:
             use_square_activation=True,
             fold_batchnorm=True,
         )
-        
+
         assert isinstance(enc_model, EncryptedSequential)
         assert isinstance(enc_model[1], EncryptedSquare)
+        assert isinstance(ctx, CKKSInferenceContext)
+
+    def test_convert_accepts_stip_architecture(self):
+        model = nn.Linear(10, 5)
+        model.eval()
+
+        enc_model, _ctx = convert(model, architecture="stip")
+
+        assert isinstance(enc_model, EncryptedLinear)
+
+
+class TestArchitectureOptions:
+
+    def test_options_default_architecture(self):
+        options = ConversionOptions()
+
+        assert options.architecture == "default"
+
+    def test_options_stip_architecture(self):
+        options = ConversionOptions(architecture="stip")
+
+        assert options.architecture == "stip"
+
+    def test_options_invalid_architecture(self):
+        with pytest.raises(ValueError, match="architecture"):
+            ConversionOptions(architecture="bogus")
 
 
 class TestEstimateDepth:

--- a/tests/test_dhp.py
+++ b/tests/test_dhp.py
@@ -1,0 +1,128 @@
+import pytest
+import torch
+
+
+def _patch_mock_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tests.mocks.mock_backend import MockCKKSConfig, MockCKKSContext
+    import cukks.context as ctx_module
+
+    monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+    monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+    monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+
+def _mock_ctx(monkeypatch: pytest.MonkeyPatch):
+    from cukks import CKKSInferenceContext
+
+    _patch_mock_backend(monkeypatch)
+    return CKKSInferenceContext(device="cpu", use_bsgs=False)
+
+
+def test_precode_weights():
+    import cukks.batching as batching_module
+
+    w_h = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float64)
+    w_h1 = torch.tensor([[0.5, -1.5], [2.5, -3.5]], dtype=torch.float64)
+
+    precoded = batching_module.DHPacker.precode_weights(w_h, w_h1)
+
+    expected = w_h.to(torch.complex128) + 1j * w_h1.to(torch.complex128)
+    assert precoded.dtype == torch.complex128
+    torch.testing.assert_close(precoded, expected)
+
+
+def test_unpack_heads_recovers_original(monkeypatch: pytest.MonkeyPatch):
+    import cukks.batching as batching_module
+
+    ctx = _mock_ctx(monkeypatch)
+    packer = batching_module.DHPacker(num_heads=2)
+
+    head_h_plain = torch.tensor([1.0, -2.0, 3.5, 0.25], dtype=torch.float64)
+    head_h1_plain = torch.tensor([-0.5, 4.0, -1.5, 2.25], dtype=torch.float64)
+
+    packed_col = ctx.encrypt(head_h_plain).add(ctx.encrypt(head_h1_plain).mul_by_i())
+    head_h, head_h1 = packer.unpack_heads([packed_col])
+
+    recovered_h = ctx.decrypt(head_h[0], shape=(4,)).to(torch.float64)
+    recovered_h1 = ctx.decrypt(head_h1[0], shape=(4,)).to(torch.float64)
+
+    torch.testing.assert_close(recovered_h, head_h_plain, rtol=1e-5, atol=1e-5)
+    torch.testing.assert_close(recovered_h1, head_h1_plain, rtol=1e-5, atol=1e-5)
+
+
+def test_repack_after_attention(monkeypatch: pytest.MonkeyPatch):
+    import cukks.batching as batching_module
+
+    ctx = _mock_ctx(monkeypatch)
+    packer = batching_module.DHPacker(num_heads=2)
+
+    att_h_plain = torch.tensor([2.0, -1.0, 0.5, 3.0], dtype=torch.float64)
+    att_h1_plain = torch.tensor([1.5, 2.5, -0.5, -4.0], dtype=torch.float64)
+
+    repacked = packer.repack_after_attention(
+        [ctx.encrypt(att_h_plain)],
+        [ctx.encrypt(att_h1_plain)],
+    )
+
+    assert len(repacked) == 1
+    expected = att_h_plain.to(torch.complex128) + 1j * att_h1_plain.to(torch.complex128)
+    actual = repacked[0]._cipher.data[:4]
+    assert actual.is_complex()
+    torch.testing.assert_close(actual, expected)
+
+
+def test_repack_then_unpack_roundtrip(monkeypatch: pytest.MonkeyPatch):
+    import cukks.batching as batching_module
+
+    ctx = _mock_ctx(monkeypatch)
+    packer = batching_module.DHPacker(num_heads=2)
+
+    torch.manual_seed(7)
+    att_h_plain = [torch.randn(6, dtype=torch.float64) for _ in range(3)]
+    att_h1_plain = [torch.randn(6, dtype=torch.float64) for _ in range(3)]
+
+    repacked = packer.repack_after_attention(
+        [ctx.encrypt(col) for col in att_h_plain],
+        [ctx.encrypt(col) for col in att_h1_plain],
+    )
+    unpacked_h, unpacked_h1 = packer.unpack_heads(repacked)
+
+    for idx in range(3):
+        recovered_h = ctx.decrypt(unpacked_h[idx], shape=(6,)).to(torch.float64)
+        recovered_h1 = ctx.decrypt(unpacked_h1[idx], shape=(6,)).to(torch.float64)
+        torch.testing.assert_close(recovered_h, att_h_plain[idx], rtol=1e-5, atol=1e-5)
+        torch.testing.assert_close(recovered_h1, att_h1_plain[idx], rtol=1e-5, atol=1e-5)
+
+
+def test_extract_final(monkeypatch: pytest.MonkeyPatch):
+    import cukks.batching as batching_module
+
+    ctx = _mock_ctx(monkeypatch)
+    packer = batching_module.DHPacker(num_heads=2)
+
+    real_part = torch.tensor([3.0, -2.0, 1.0, 0.0], dtype=torch.float64)
+    imag_part = torch.tensor([10.0, -20.0, 30.0, -40.0], dtype=torch.float64)
+
+    accumulated = ctx.encrypt(real_part).add(ctx.encrypt(imag_part).mul_by_i())
+    final = packer.extract_final(accumulated)
+
+    recovered = ctx.decrypt(final, shape=(4,)).to(torch.float64)
+    torch.testing.assert_close(recovered, real_part, rtol=1e-5, atol=1e-5)
+    assert not final._cipher.data[:4].is_complex()
+
+
+def test_num_heads_must_be_even():
+    import cukks.batching as batching_module
+
+    with pytest.raises(ValueError, match="must be even"):
+        batching_module.DHPacker(num_heads=3)
+
+
+def test_num_heads_must_be_positive():
+    import cukks.batching as batching_module
+
+    with pytest.raises(ValueError, match="must be positive"):
+        batching_module.DHPacker(num_heads=0)
+
+    with pytest.raises(ValueError, match="must be positive"):
+        batching_module.DHPacker(num_heads=-2)

--- a/tests/test_inverse_free_layernorm.py
+++ b/tests/test_inverse_free_layernorm.py
@@ -1,0 +1,501 @@
+"""Tests for inverse-free LayerNorm: detection, forward, converter integration, and bias scaling."""
+
+import math
+
+import pytest
+import torch
+import torch.nn as nn
+
+from cukks.analysis.inverse_free_detect import detect_inverse_free_layernorms
+from cukks.nn.inverse_free_layernorm import EncryptedInverseFreeLayerNorm
+from cukks.converter import ModelConverter, ConversionOptions
+from cukks.nn import EncryptedLayerNorm, EncryptedLinear
+
+
+# ============================================================================
+# Helper models for detection tests
+# ============================================================================
+
+class TwoLNLinearReLU(nn.Module):
+    """LN → Linear → ReLU → LN.  First LN is eligible."""
+
+    def __init__(self, d: int = 16):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(d)
+        self.fc = nn.Linear(d, d)
+        self.act = nn.ReLU()
+        self.norm2 = nn.LayerNorm(d)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.norm2(self.act(self.fc(self.norm1(x))))
+
+
+class TwoLNWithGELU(nn.Module):
+    """LN → Linear → GELU → LN.  GELU is NOT homogeneous → not eligible."""
+
+    def __init__(self, d: int = 16):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(d)
+        self.fc = nn.Linear(d, d)
+        self.act = nn.GELU()
+        self.norm2 = nn.LayerNorm(d)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.norm2(self.act(self.fc(self.norm1(x))))
+
+
+class SingleLN(nn.Module):
+    """Only one LN → no pair → not eligible."""
+
+    def __init__(self, d: int = 16):
+        super().__init__()
+        self.norm = nn.LayerNorm(d)
+        self.fc = nn.Linear(d, d)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc(self.norm(x))
+
+
+class ThreeLNChain(nn.Module):
+    """LN → Linear → ReLU → LN → Linear → ReLU → LN.
+    First two LNs are eligible."""
+
+    def __init__(self, d: int = 16):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(d)
+        self.fc1 = nn.Linear(d, d)
+        self.act1 = nn.ReLU()
+        self.norm2 = nn.LayerNorm(d)
+        self.fc2 = nn.Linear(d, d)
+        self.act2 = nn.ReLU()
+        self.norm3 = nn.LayerNorm(d)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = self.norm1(x)
+        x = self.act1(self.fc1(x))
+        x = self.norm2(x)
+        x = self.act2(self.fc2(x))
+        x = self.norm3(x)
+        return x
+
+
+class TwoLNWithDropout(nn.Module):
+    """LN → Linear → Dropout → ReLU → LN.  Dropout is safe → eligible."""
+
+    def __init__(self, d: int = 16):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(d)
+        self.fc = nn.Linear(d, d)
+        self.drop = nn.Dropout(0.1)
+        self.act = nn.ReLU()
+        self.norm2 = nn.LayerNorm(d)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.norm2(self.act(self.drop(self.fc(self.norm1(x)))))
+
+
+class TwoLNWithResidual(nn.Module):
+    """LN → Linear → ReLU + residual add → LN.
+    Residual add IS allowed between the two LNs."""
+
+    def __init__(self, d: int = 16):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(d)
+        self.fc = nn.Linear(d, d)
+        self.act = nn.ReLU()
+        self.norm2 = nn.LayerNorm(d)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = self.norm1(x)
+        h = self.act(self.fc(h))
+        h = h + x  # residual
+        return self.norm2(h)
+
+
+class NoLNModel(nn.Module):
+    """No LayerNorm at all."""
+
+    def __init__(self, d: int = 16):
+        super().__init__()
+        self.fc1 = nn.Linear(d, d)
+        self.act = nn.ReLU()
+        self.fc2 = nn.Linear(d, d)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(self.act(self.fc1(x)))
+
+
+# ============================================================================
+# Detection tests
+# ============================================================================
+
+class TestDetectInverseFreeLayerNorms:
+
+    def test_basic_eligible_pair(self):
+        model = TwoLNLinearReLU(16).eval()
+        eligible = detect_inverse_free_layernorms(model)
+        assert "norm1" in eligible
+        assert "norm2" not in eligible  # norm2 has no cancelling LN after it
+
+    def test_gelu_breaks_eligibility(self):
+        model = TwoLNWithGELU(16).eval()
+        eligible = detect_inverse_free_layernorms(model)
+        assert "norm1" not in eligible
+
+    def test_single_ln_not_eligible(self):
+        model = SingleLN(16).eval()
+        eligible = detect_inverse_free_layernorms(model)
+        assert len(eligible) == 0
+
+    def test_three_ln_chain(self):
+        model = ThreeLNChain(16).eval()
+        eligible = detect_inverse_free_layernorms(model)
+        assert "norm1" in eligible
+        assert "norm2" in eligible
+        assert "norm3" not in eligible
+
+    def test_dropout_is_safe(self):
+        model = TwoLNWithDropout(16).eval()
+        eligible = detect_inverse_free_layernorms(model)
+        assert "norm1" in eligible
+
+    def test_residual_add_is_safe(self):
+        model = TwoLNWithResidual(16).eval()
+        eligible = detect_inverse_free_layernorms(model)
+        assert "norm1" in eligible
+
+    def test_no_ln_returns_empty(self):
+        model = NoLNModel(16).eval()
+        eligible = detect_inverse_free_layernorms(model)
+        assert len(eligible) == 0
+
+    def test_returns_frozenset(self):
+        model = TwoLNLinearReLU(16).eval()
+        eligible = detect_inverse_free_layernorms(model)
+        assert isinstance(eligible, frozenset)
+
+
+# ============================================================================
+# EncryptedInverseFreeLayerNorm unit tests
+# ============================================================================
+
+class TestEncryptedInverseFreeLayerNorm:
+
+    def test_from_torch(self):
+        ln = nn.LayerNorm(32)
+        enc_ln = EncryptedInverseFreeLayerNorm.from_torch(ln)
+        assert enc_ln.normalized_shape == [32]
+        assert enc_ln.lam == 0.01
+        assert enc_ln.weight.shape == (32,)
+        assert enc_ln.bias.shape == (32,)
+
+    def test_from_torch_custom_lam(self):
+        ln = nn.LayerNorm(64)
+        enc_ln = EncryptedInverseFreeLayerNorm.from_torch(ln, lam=0.005)
+        assert enc_ln.lam == 0.005
+
+    def test_mult_depth(self):
+        enc_ln = EncryptedInverseFreeLayerNorm(16)
+        assert enc_ln.mult_depth() == 5
+
+    def test_extra_repr(self):
+        enc_ln = EncryptedInverseFreeLayerNorm(32, lam=0.02)
+        r = enc_ln.extra_repr()
+        assert "inverse_free=True" in r
+        assert "lam=0.02" in r
+
+    def test_weight_bias_default(self):
+        enc_ln = EncryptedInverseFreeLayerNorm(16)
+        assert torch.allclose(enc_ln.weight, torch.ones(16, dtype=torch.float64))
+        assert torch.allclose(enc_ln.bias, torch.zeros(16, dtype=torch.float64))
+
+    def test_weight_bias_copied(self):
+        w = torch.randn(16)
+        b = torch.randn(16)
+        enc_ln = EncryptedInverseFreeLayerNorm(16, weight=w, bias=b)
+        assert torch.allclose(enc_ln.weight, w.to(torch.float64))
+        assert torch.allclose(enc_ln.bias, b.to(torch.float64))
+
+
+# ============================================================================
+# Taylor sqrt unit tests
+# ============================================================================
+
+class TestTaylorSqrt:
+    """Test the Taylor sqrt approximation with plain tensors to verify math."""
+
+    @staticmethod
+    def _plain_taylor_sqrt(x: torch.Tensor) -> torch.Tensor:
+        """Reference implementation: sqrt(x) ≈ 1 + 0.5(x-1) - 0.125(x-1)²"""
+        t = x - 1.0
+        return 1.0 + 0.5 * t - 0.125 * t ** 2
+
+    def test_near_one(self):
+        x = torch.tensor([1.0])
+        approx = self._plain_taylor_sqrt(x)
+        assert torch.allclose(approx, torch.tensor([1.0]), atol=1e-10)
+
+    def test_range_0_to_2(self):
+        # The Taylor sqrt is most accurate near x=1. At the boundaries
+        # (x→0, x→2) the 2nd-order approximation degrades.  λ is chosen
+        # so λ·Σz² stays in a narrow band around 1; test that band.
+        x = torch.linspace(0.5, 1.5, 100)
+        approx = self._plain_taylor_sqrt(x)
+        exact = torch.sqrt(x)
+        rel_err = ((approx - exact) / exact).abs().max()
+        assert rel_err < 0.05  # tight bound in the practical range
+
+    def test_at_half(self):
+        x = torch.tensor([0.5])
+        approx = self._plain_taylor_sqrt(x).item()
+        exact = math.sqrt(0.5)
+        assert abs(approx - exact) / exact < 0.05
+
+
+# ============================================================================
+# Converter integration tests
+# ============================================================================
+
+class TestConverterInverseFreeIntegration:
+
+    def test_stip_converts_eligible_ln_to_inverse_free(self):
+        """When architecture='stip', eligible LNs become EncryptedInverseFreeLayerNorm."""
+        model = TwoLNLinearReLU(16).eval()
+        options = ConversionOptions(architecture="stip")
+        converter = ModelConverter(options)
+        enc_model = converter.convert(model)
+
+        # norm1 is eligible → should be inverse-free
+        assert isinstance(enc_model["norm1"], EncryptedInverseFreeLayerNorm)
+        # norm2 is NOT eligible (no LN after it) → standard
+        assert isinstance(enc_model["norm2"], EncryptedLayerNorm)
+
+    def test_default_architecture_never_uses_inverse_free(self):
+        """Default architecture should never produce inverse-free LNs."""
+        model = TwoLNLinearReLU(16).eval()
+        options = ConversionOptions(architecture="default")
+        converter = ModelConverter(options)
+        enc_model = converter.convert(model)
+
+        assert isinstance(enc_model["norm1"], EncryptedLayerNorm)
+        assert isinstance(enc_model["norm2"], EncryptedLayerNorm)
+
+    def test_stip_gelu_model_keeps_standard_ln(self):
+        """GELU breaks eligibility → both LNs stay standard even under stip."""
+        model = TwoLNWithGELU(16).eval()
+        options = ConversionOptions(architecture="stip")
+        converter = ModelConverter(options)
+        enc_model = converter.convert(model)
+
+        assert isinstance(enc_model["norm1"], EncryptedLayerNorm)
+        assert isinstance(enc_model["norm2"], EncryptedLayerNorm)
+
+    def test_stip_three_ln_chain(self):
+        """Three LN chain: first two eligible, third not."""
+        model = ThreeLNChain(16).eval()
+        options = ConversionOptions(architecture="stip")
+        converter = ModelConverter(options)
+        enc_model = converter.convert(model)
+
+        assert isinstance(enc_model["norm1"], EncryptedInverseFreeLayerNorm)
+        assert isinstance(enc_model["norm2"], EncryptedInverseFreeLayerNorm)
+        assert isinstance(enc_model["norm3"], EncryptedLayerNorm)
+
+    def test_stip_with_dropout(self):
+        """Dropout doesn't break eligibility."""
+        model = TwoLNWithDropout(16).eval()
+        options = ConversionOptions(architecture="stip")
+        converter = ModelConverter(options)
+        enc_model = converter.convert(model)
+
+        assert isinstance(enc_model["norm1"], EncryptedInverseFreeLayerNorm)
+
+    def test_path_tracking_resets_between_conversions(self):
+        """_current_path should be empty after conversion finishes."""
+        model = TwoLNLinearReLU(16).eval()
+        options = ConversionOptions(architecture="stip")
+        converter = ModelConverter(options)
+        converter.convert(model)
+
+        assert converter._current_path == []
+
+    def test_no_ln_model_stip(self):
+        """Model without LN under stip should convert normally."""
+        model = NoLNModel(16).eval()
+        options = ConversionOptions(architecture="stip")
+        converter = ModelConverter(options)
+        enc_model = converter.convert(model)
+
+        # Should complete without error
+        assert enc_model is not None
+
+
+# ============================================================================
+# Nested module path tracking tests
+# ============================================================================
+
+class NestedTransformerBlock(nn.Module):
+    """Simulates nested module structure: block.norm1 → block.fc → block.act → block.norm2."""
+
+    def __init__(self, d: int = 16):
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.LayerNorm(d),
+            nn.Linear(d, d),
+            nn.ReLU(),
+            nn.LayerNorm(d),
+        )
+        self.head = nn.Linear(d, d)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.head(self.block(x))
+
+
+class TestNestedPathTracking:
+
+    def test_nested_sequential_eligible(self):
+        """Detection should work with nested nn.Sequential containers."""
+        model = NestedTransformerBlock(16).eval()
+        eligible = detect_inverse_free_layernorms(model)
+        # torch.fx flattens Sequential to block.0, block.1, etc.
+        assert "block.0" in eligible  # first LN in sequential
+
+    def test_nested_converter_uses_inverse_free(self):
+        """Converter should track nested paths and apply inverse-free to eligible LNs."""
+        model = NestedTransformerBlock(16).eval()
+        options = ConversionOptions(architecture="stip")
+        converter = ModelConverter(options)
+        enc_model = converter.convert(model)
+
+        # The model converts to EncryptedSequential with a nested EncryptedSequential
+        # for self.block. Access the inner block's first element (LN).
+        inner_block = enc_model["block"]
+        assert isinstance(inner_block["0"], EncryptedInverseFreeLayerNorm)
+        assert isinstance(inner_block["3"], EncryptedLayerNorm)
+
+
+# ============================================================================
+# Bias scaling (σ propagation) tests
+# ============================================================================
+
+def _patch_mock_backend(monkeypatch):
+    from tests.mocks.mock_backend import MockCKKSConfig, MockCKKSContext
+    import cukks.context as ctx_module
+
+    monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+    monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+    monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+
+class TestSigmaFactorPropagation:
+
+    def test_inverse_free_ln_stores_sigma_on_output(self, monkeypatch):
+        from cukks import CKKSInferenceContext
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False)
+        x = ctx.encrypt(torch.randn(16, dtype=torch.float64))
+
+        enc_ln = EncryptedInverseFreeLayerNorm(16)
+        result = enc_ln(x)
+
+        assert result._sigma_factor is not None
+
+    def test_standard_ln_clears_sigma(self, monkeypatch):
+        from cukks import CKKSInferenceContext
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False)
+        x = ctx.encrypt(torch.randn(16, dtype=torch.float64))
+
+        enc_inv_ln = EncryptedInverseFreeLayerNorm(16)
+        mid = enc_inv_ln(x)
+        assert mid._sigma_factor is not None
+
+        enc_std_ln = EncryptedLayerNorm(16)
+        out = enc_std_ln(mid)
+        assert out._sigma_factor is None
+
+    def test_sigma_propagates_through_operations(self, monkeypatch):
+        from cukks import CKKSInferenceContext
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False)
+        x = ctx.encrypt(torch.randn(16, dtype=torch.float64))
+
+        enc_ln = EncryptedInverseFreeLayerNorm(16)
+        mid = enc_ln(x)
+
+        added = mid.add(1.0)
+        assert added._sigma_factor is not None
+
+        cloned = mid.clone()
+        assert cloned._sigma_factor is not None
+
+    def test_linear_uses_sigma_for_bias_scaling(self, monkeypatch):
+        from cukks import CKKSInferenceContext
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False)
+        x = ctx.encrypt(torch.randn(16, dtype=torch.float64))
+
+        enc_ln = EncryptedInverseFreeLayerNorm(16)
+        mid = enc_ln(x)
+        assert mid._sigma_factor is not None
+
+        linear = nn.Linear(16, 8)
+        enc_linear = EncryptedLinear.from_torch(linear)
+        out = enc_linear(mid)
+
+        assert out._sigma_factor is not None
+
+    def test_linear_without_sigma_uses_normal_path(self, monkeypatch):
+        from cukks import CKKSInferenceContext
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False)
+        x = ctx.encrypt(torch.randn(16, dtype=torch.float64))
+
+        linear = nn.Linear(16, 8)
+        enc_linear = EncryptedLinear.from_torch(linear)
+        out = enc_linear(x)
+
+        assert out._sigma_factor is None
+
+    def test_linear_no_bias_ignores_sigma(self, monkeypatch):
+        from cukks import CKKSInferenceContext
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False)
+        x = ctx.encrypt(torch.randn(16, dtype=torch.float64))
+
+        enc_ln = EncryptedInverseFreeLayerNorm(16)
+        mid = enc_ln(x)
+
+        linear = nn.Linear(16, 8, bias=False)
+        enc_linear = EncryptedLinear.from_torch(linear)
+        out = enc_linear(mid)
+
+        assert out._sigma_factor is not None
+
+    def test_full_chain_inv_ln_linear_relu_std_ln(self, monkeypatch):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedReLU
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False)
+        x = ctx.encrypt(torch.randn(16, dtype=torch.float64))
+
+        inv_ln = EncryptedInverseFreeLayerNorm(16)
+        linear = EncryptedLinear.from_torch(nn.Linear(16, 16))
+        relu = EncryptedReLU(degree=4)
+        std_ln = EncryptedLayerNorm(16)
+
+        h = inv_ln(x)
+        assert h._sigma_factor is not None
+        h = linear(h)
+        assert h._sigma_factor is not None
+        h = relu(h)
+        assert h._sigma_factor is not None
+        h = std_ln(h)
+        assert h._sigma_factor is None

--- a/tests/test_nn_modules.py
+++ b/tests/test_nn_modules.py
@@ -19,7 +19,7 @@ from cukks.nn import (
     EncryptedLayerNorm,
     EncryptedDropout,
 )
-from cukks.converter import ModelConverter
+from cukks.converter import ConversionOptions, ModelConverter
 
 
 class TestEncryptedLinear:
@@ -327,12 +327,18 @@ class TestAttention:
         assert attn.num_heads == 4
         assert attn.head_dim == 16
         assert attn.softmax_degree == 4
+        assert attn.normalization_mode == "power_softmax"
+        assert attn.gaussian_gamma == 0.25
         assert attn.scale == 1.0 / (16 ** 0.5)
 
     def test_attention_creation_invalid_heads(self):
         """Test that invalid num_heads raises ValueError."""
         with pytest.raises(ValueError, match="must be divisible"):
             EncryptedApproxAttention(embed_dim=64, num_heads=5)
+
+    def test_attention_creation_invalid_normalization_mode(self):
+        with pytest.raises(ValueError, match="normalization_mode"):
+            EncryptedApproxAttention(embed_dim=64, num_heads=4, normalization_mode="softmax")
 
     def test_attention_from_torch(self):
         """Test conversion from PyTorch MultiheadAttention."""
@@ -347,6 +353,20 @@ class TestAttention:
         assert enc_attn.k_weight is not None
         assert enc_attn.v_weight is not None
         assert enc_attn.out_weight is not None
+
+    def test_attention_from_torch_gaussian_mode(self):
+        torch_attn = nn.MultiheadAttention(embed_dim=32, num_heads=4, batch_first=True)
+        torch_attn.eval()
+
+        enc_attn = EncryptedApproxAttention.from_torch(
+            torch_attn,
+            softmax_degree=4,
+            normalization_mode="gaussian",
+            gaussian_gamma=0.2,
+        )
+
+        assert enc_attn.normalization_mode == "gaussian"
+        assert enc_attn.gaussian_gamma == 0.2
 
     def test_attention_mult_depth(self):
         """Test multiplicative depth estimation."""
@@ -409,13 +429,21 @@ class TestAttention:
 
     def test_attention_repr(self):
         """Test string representation."""
-        attn = EncryptedApproxAttention(embed_dim=64, num_heads=8, softmax_degree=6)
+        attn = EncryptedApproxAttention(
+            embed_dim=64,
+            num_heads=8,
+            softmax_degree=6,
+            normalization_mode="gaussian",
+            gaussian_gamma=0.2,
+        )
         repr_str = repr(attn)
         
         assert "EncryptedApproxAttention" in repr_str
         assert "embed_dim=64" in repr_str
         assert "num_heads=8" in repr_str
         assert "softmax_degree=6" in repr_str
+        assert "normalization_mode=gaussian" in repr_str
+        assert "gaussian_gamma=0.2" in repr_str
 
     def test_taylor_exp_coeffs(self):
         """Test Taylor expansion coefficients for exp(x)."""
@@ -434,10 +462,15 @@ class TestAttentionMultiToken:
     """Tests for seq_len > 1 attention using Power-Softmax."""
     
     @pytest.mark.parametrize("seq_len", [2, 4, 8])
-    def test_attention_multi_token_forward(self, mock_enc_context, seq_len):
+    @pytest.mark.parametrize("normalization_mode", ["power_softmax", "gaussian"])
+    def test_attention_multi_token_forward(self, mock_enc_context, seq_len, normalization_mode):
         """Test forward pass with multiple tokens."""
         embed_dim = 16
-        attn = EncryptedApproxAttention(embed_dim=embed_dim, num_heads=2)
+        attn = EncryptedApproxAttention(
+            embed_dim=embed_dim,
+            num_heads=2,
+            normalization_mode=normalization_mode,
+        )
         
         q = [mock_enc_context.encrypt(torch.randn(embed_dim) * 0.5) for _ in range(seq_len)]
         k = [mock_enc_context.encrypt(torch.randn(embed_dim) * 0.5) for _ in range(seq_len)]
@@ -462,6 +495,13 @@ class TestAttentionMultiToken:
         
         with pytest.raises(NotImplementedError, match="Maximum is 8"):
             attn.forward_attention(q, k, v)
+
+    def test_single_tensor_seq_len_gt_1_directs_to_supported_api(self, mock_enc_context):
+        attn = EncryptedApproxAttention(embed_dim=8, num_heads=2)
+        query = mock_enc_context.encrypt(torch.randn(4, 8) * 0.5)
+
+        with pytest.raises(NotImplementedError, match=r"List\[EncryptedTensor\].*max seq_len=8"):
+            attn.forward_attention(query, query, query)
 
 
 class TestLayerNorm:
@@ -752,6 +792,85 @@ class TestConverterNewModules:
         enc_attn = converter._convert_attention(torch_attn)
         
         assert isinstance(enc_attn, EncryptedApproxAttention)
+
+    def test_converter_attention_uses_gaussian_mode_from_options(self):
+        torch_attn = nn.MultiheadAttention(embed_dim=8, num_heads=2, batch_first=True)
+        torch_attn.eval()
+
+        converter = ModelConverter(
+            ConversionOptions(
+                attention_normalization_mode="gaussian",
+                attention_gaussian_gamma=0.2,
+            )
+        )
+        enc_attn = converter._convert_attention(torch_attn)
+
+        assert enc_attn.normalization_mode == "gaussian"
+        assert enc_attn.gaussian_gamma == 0.2
+
+    @pytest.mark.parametrize("normalization_mode", ["power_softmax", "gaussian"])
+    def test_converter_attention_supports_packed_multi_token_input(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        normalization_mode: str,
+    ):
+        from cukks import CKKSInferenceContext
+        from tests.mocks.mock_backend import MockCKKSContext, MockCKKSConfig
+        import cukks.context as ctx_module
+
+        monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+        monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+        monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+        torch.manual_seed(0)
+        torch_attn = nn.MultiheadAttention(embed_dim=4, num_heads=2, batch_first=True)
+        torch_attn.eval()
+
+        converter = ModelConverter(
+            ConversionOptions(attention_normalization_mode=normalization_mode)
+        )
+        enc_attn = converter._convert_attention(torch_attn)
+
+        ctx = CKKSInferenceContext(device="cpu")
+        samples = [
+            torch.tensor([[0.1, 0.2, 0.3, 0.4], [0.4, 0.3, 0.2, 0.1]]),
+            torch.tensor([[0.5, 0.1, 0.2, 0.7], [0.6, 0.2, 0.3, 0.1]]),
+        ]
+        enc_batch = ctx.encrypt_batch(samples)
+
+        enc_output = enc_attn(enc_batch)
+        recovered = ctx.decrypt_batch(enc_output, sample_shape=(2, 4))
+
+        expected = []
+        for sample in samples:
+            tokens = [ctx.encrypt(sample[i]) for i in range(sample.shape[0])]
+            enc_tokens = enc_attn.forward_attention(tokens, tokens, tokens)
+            assert isinstance(enc_tokens, list)
+            expected.append(torch.stack([ctx.decrypt(token) for token in enc_tokens]))
+
+        torch.testing.assert_close(recovered[0], expected[0], rtol=1e-4, atol=1e-4)
+        torch.testing.assert_close(recovered[1], expected[1], rtol=1e-4, atol=1e-4)
+
+    def test_converter_attention_packed_seq_len_9_raises(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+        from tests.mocks.mock_backend import MockCKKSContext, MockCKKSConfig
+        import cukks.context as ctx_module
+
+        monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+        monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+        monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+        torch_attn = nn.MultiheadAttention(embed_dim=4, num_heads=2, batch_first=True)
+        torch_attn.eval()
+
+        converter = ModelConverter()
+        enc_attn = converter._convert_attention(torch_attn)
+
+        ctx = CKKSInferenceContext(device="cpu")
+        enc_batch = ctx.encrypt_batch([torch.randn(9, 4) * 0.1])
+
+        with pytest.raises(NotImplementedError, match="Maximum is 8"):
+            enc_attn(enc_batch)
 
     def test_converter_grouped_conv(self):
         """Test converter handles grouped Conv2d."""

--- a/tests/test_rihp.py
+++ b/tests/test_rihp.py
@@ -1,0 +1,109 @@
+import pytest
+import torch
+
+
+def _patch_mock_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tests.mocks.mock_backend import MockCKKSConfig, MockCKKSContext
+    import cukks.context as ctx_module
+
+    monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+    monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+    monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+
+def _mock_ctx(monkeypatch: pytest.MonkeyPatch):
+    from cukks import CKKSInferenceContext
+
+    _patch_mock_backend(monkeypatch)
+    return CKKSInferenceContext(device="cpu", use_bsgs=False)
+
+
+def test_pack_hybrid_creates_complex_data(monkeypatch: pytest.MonkeyPatch):
+    import cukks.batching as batching_module
+
+    m = 4
+    ctx = _mock_ctx(monkeypatch)
+    packer = batching_module.RIHPacker(seq_len=m)
+
+    keys_plain = [
+        torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float64),
+        torch.tensor([-1.0, 0.5, 2.0, -3.0], dtype=torch.float64),
+    ]
+    keys = [ctx.encrypt(col) for col in keys_plain]
+
+    hybrid = packer.pack_hybrid(keys)
+
+    assert len(hybrid) == len(keys_plain)
+    for idx, packed_col in enumerate(hybrid):
+        expected = keys_plain[idx].to(torch.complex128) + 1j * torch.roll(
+            keys_plain[idx], shifts=-(m // 2)
+        ).to(torch.complex128)
+        actual = packed_col._cipher.data[:m]
+        assert actual.is_complex()
+        torch.testing.assert_close(actual, expected)
+
+
+def test_unpack_recovers_original_diagonals(monkeypatch: pytest.MonkeyPatch):
+    import cukks.batching as batching_module
+
+    m = 6
+    half = m // 2
+    ctx = _mock_ctx(monkeypatch)
+    packer = batching_module.RIHPacker(seq_len=m)
+
+    torch.manual_seed(0)
+    plain_diagonals = [torch.randn(m, dtype=torch.float64) for _ in range(m)]
+
+    hybrid_results = []
+    for r in range(half):
+        real_diag = ctx.encrypt(plain_diagonals[r])
+        imag_diag = ctx.encrypt(plain_diagonals[r + half])
+        hybrid_results.append(real_diag.add(imag_diag.mul_by_i()))
+
+    unpacked = packer.unpack_diagonals(hybrid_results)
+
+    assert len(unpacked) == m
+    for r in range(m):
+        recovered = ctx.decrypt(unpacked[r], shape=(m,)).to(torch.float64)
+        torch.testing.assert_close(recovered, plain_diagonals[r], rtol=1e-5, atol=1e-5)
+
+
+def test_halved_ccmm_matches_naive(monkeypatch: pytest.MonkeyPatch):
+    import cukks.batching as batching_module
+
+    m = 6
+    d = 3
+    ctx = _mock_ctx(monkeypatch)
+    packer = batching_module.RIHPacker(seq_len=m)
+
+    torch.manual_seed(1)
+    queries_plain = [torch.randn(m, dtype=torch.float64) for _ in range(d)]
+    keys_plain = [torch.randn(m, dtype=torch.float64) for _ in range(d)]
+
+    queries = [ctx.encrypt(col) for col in queries_plain]
+    keys = [ctx.encrypt(col) for col in keys_plain]
+
+    keys_hybrid = packer.pack_hybrid(keys)
+    hybrid_results = packer.halved_ccmm(queries, keys_hybrid)
+    diagonals = packer.unpack_diagonals(hybrid_results)
+
+    assert len(hybrid_results) == m // 2
+    assert len(diagonals) == m
+
+    expected_diagonals = []
+    for rotation in range(m):
+        acc = torch.zeros(m, dtype=torch.float64)
+        for col in range(d):
+            acc = acc + queries_plain[col] * torch.roll(keys_plain[col], shifts=-rotation)
+        expected_diagonals.append(acc)
+
+    for rotation in range(m):
+        recovered = ctx.decrypt(diagonals[rotation], shape=(m,)).to(torch.float64)
+        torch.testing.assert_close(recovered, expected_diagonals[rotation], rtol=1e-4, atol=1e-4)
+
+
+def test_seq_len_must_be_even():
+    import cukks.batching as batching_module
+
+    with pytest.raises(ValueError, match="must be even"):
+        batching_module.RIHPacker(seq_len=3)

--- a/tests/test_stip_attention.py
+++ b/tests/test_stip_attention.py
@@ -1,0 +1,257 @@
+from typing import Any
+
+import pytest
+import torch
+
+
+def _patch_mock_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tests.mocks.mock_backend import MockCKKSConfig, MockCKKSContext
+    import cukks.context as ctx_module
+
+    monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+    monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+    monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+
+class TestSTIPAttention:
+
+    def test_encrypt_sequence_sets_fresh_provenance(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(2, 4), num_heads=2)
+
+        assert getattr(enc, "_packing_layout", None) is not None
+        assert getattr(enc, "_stip_layout_fresh", False) is True
+
+    def test_generic_ops_do_not_preserve_fresh_provenance(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(2, 4), num_heads=2)
+        rotated = enc.rotate(0)
+
+        assert getattr(rotated, "_packing_layout", None) is not None
+        assert getattr(rotated, "_stip_layout_fresh", False) is False
+
+    def test_clone_preserves_fresh_provenance(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(2, 4), num_heads=2)
+        cloned = enc.clone()
+
+        assert getattr(cloned, "_stip_layout_fresh", False) is True
+
+    def test_forward_routes_stip_layout_to_stip_path(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(2, 4), num_heads=2)
+        attn = EncryptedApproxAttention(embed_dim=4, num_heads=2)
+
+        called = {"stip": False}
+
+        def fake_stip(x: Any):
+            called["stip"] = True
+            return x
+
+        monkeypatch.setattr(attn, "_forward_attention_stip", fake_stip)
+
+        out = attn(enc)
+
+        assert called["stip"] is True
+        assert out is enc
+
+    def test_default_single_tensor_path_unchanged(self, mock_enc_context: Any):
+        from cukks.nn import EncryptedApproxAttention
+
+        attn = EncryptedApproxAttention(embed_dim=8, num_heads=2, softmax_degree=4)
+        enc_x = mock_enc_context.encrypt(torch.randn(1, 8) * 0.5)
+
+        out: Any = attn(enc_x)
+
+        dec = mock_enc_context.decrypt(out)
+        assert torch.isfinite(dec).all()
+
+    def test_packed_batch_path_unchanged(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu")
+        enc_batch = ctx.encrypt_batch([
+            torch.tensor([[0.1, 0.2], [0.3, 0.4]]),
+            torch.tensor([[0.5, 0.1], [0.2, 0.7]]),
+        ])
+        attn = EncryptedApproxAttention(embed_dim=2, num_heads=1)
+
+        out = attn(enc_batch)
+
+        recovered = ctx.decrypt_batch(out, sample_shape=(2, 2))
+        assert len(recovered) == 2
+
+    @pytest.mark.parametrize("normalization_mode", ["power_softmax", "gaussian"])
+    @pytest.mark.parametrize("seq_len", [2, 4])
+    def test_stip_attention_matches_list_path(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        normalization_mode: str,
+        seq_len: int,
+    ):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+
+        _patch_mock_backend(monkeypatch)
+
+        torch.manual_seed(0)
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        source = torch.randn(seq_len, 4, dtype=torch.float64) * 0.1
+        enc = ctx.encrypt_sequence(source, num_heads=2)
+        attn = EncryptedApproxAttention(embed_dim=4, num_heads=2, normalization_mode=normalization_mode)
+
+        stip_out = attn(enc)
+        stip_plain = ctx.decrypt_sequence(stip_out)
+
+        tokens: Any = [ctx.encrypt(source[i]) for i in range(seq_len)]
+        list_out = attn.forward_attention(tokens, tokens, tokens)
+        assert isinstance(list_out, list)
+        list_plain = torch.stack([ctx.decrypt(token) for token in list_out])
+
+        if normalization_mode == "gaussian":
+            torch.testing.assert_close(stip_plain, list_plain, rtol=3e-1, atol=2e-2)
+        else:
+            torch.testing.assert_close(stip_plain, list_plain, rtol=1e-4, atol=1e-4)
+
+    def test_stip_output_preserves_layout_and_freshness(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(2, 4, dtype=torch.float64) * 0.1, num_heads=2)
+        attn = EncryptedApproxAttention(embed_dim=4, num_heads=2)
+
+        out = attn(enc)
+
+        assert out.shape == (2, 4)
+        assert getattr(out, "_packed_batch", False) is False
+        assert getattr(out, "_packing_layout", None) == getattr(enc, "_packing_layout", None)
+        assert getattr(out, "_stip_layout_fresh", False) is True
+
+    def test_stip_attention_rejects_missing_fresh_provenance(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(2, 4), num_heads=2)
+        stale = enc.rotate(0)
+        attn = EncryptedApproxAttention(embed_dim=4, num_heads=2)
+
+        with pytest.raises(RuntimeError, match="fresh sequence-layout provenance"):
+            attn(stale)
+
+    def test_stip_attention_rejects_d_model_mismatch(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(2, 4), num_heads=2)
+        attn = EncryptedApproxAttention(embed_dim=8, num_heads=2)
+
+        with pytest.raises(RuntimeError, match="d_model"):
+            attn(enc)
+
+    def test_stip_attention_rejects_num_heads_mismatch(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(2, 4), num_heads=2)
+        attn = EncryptedApproxAttention(embed_dim=4, num_heads=1)
+
+        with pytest.raises(RuntimeError, match="num_heads"):
+            attn(enc)
+
+    def test_stip_attention_rejects_shape_mismatch(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(2, 4), num_heads=2)
+        reshaped = enc.view(8)
+        reshaped._stip_layout_fresh = True
+        attn = EncryptedApproxAttention(embed_dim=4, num_heads=2)
+
+        with pytest.raises(RuntimeError, match="tensor shape matching layout"):
+            attn(reshaped)
+
+    def test_stip_attention_rejects_block_padding(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(2, 4), num_heads=2, block_size=8)
+        attn = EncryptedApproxAttention(embed_dim=4, num_heads=2)
+
+        with pytest.raises(NotImplementedError, match="block_size == d_model"):
+            attn(enc)
+
+    def test_stip_attention_rejects_seq_len_above_limit(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+        from cukks.nn import EncryptedApproxAttention
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(9, 4), num_heads=2)
+        attn = EncryptedApproxAttention(embed_dim=4, num_heads=2)
+
+        with pytest.raises(NotImplementedError, match="Maximum is 8"):
+            attn(enc)
+
+    def test_decrypt_sequence_rejects_missing_fresh_provenance(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(2, 4), num_heads=2)
+        stale = enc.rotate(0)
+
+        with pytest.raises(ValueError, match="fresh STIP sequence-layout provenance"):
+            ctx.decrypt_sequence(stale)
+
+    def test_decrypt_sequence_rejects_shape_mismatch(self, monkeypatch: pytest.MonkeyPatch):
+        from cukks import CKKSInferenceContext
+
+        _patch_mock_backend(monkeypatch)
+
+        ctx = CKKSInferenceContext(device="cpu", use_bsgs=False, architecture="stip")
+        enc = ctx.encrypt_sequence(torch.randn(2, 4), num_heads=2)
+        reshaped = enc.view(8)
+        reshaped._stip_layout_fresh = True
+
+        with pytest.raises(ValueError, match="shape does not match STIP packing layout"):
+            ctx.decrypt_sequence(reshaped)

--- a/tests/test_stip_wiring.py
+++ b/tests/test_stip_wiring.py
@@ -1,0 +1,206 @@
+import pytest
+import torch
+from typing import Any
+
+
+def _patch_mock_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    from tests.mocks.mock_backend import MockCKKSConfig, MockCKKSContext
+    import cukks.context as ctx_module
+
+    monkeypatch.setattr(ctx_module, "CKKSConfig", MockCKKSConfig, raising=False)
+    monkeypatch.setattr(ctx_module, "CKKSContext", MockCKKSContext, raising=False)
+    monkeypatch.setattr(ctx_module, "_BACKEND_AVAILABLE", True, raising=False)
+
+
+def _mock_ctx(monkeypatch: pytest.MonkeyPatch):
+    from cukks import CKKSInferenceContext
+
+    _patch_mock_backend(monkeypatch)
+    return CKKSInferenceContext(device="cpu", use_bsgs=False)
+
+
+def _encrypt_columns(ctx: Any, plain: torch.Tensor) -> list[Any]:
+    return [ctx.encrypt(plain[:, col]) for col in range(plain.shape[1])]
+
+
+def _decrypt_columns(ctx: Any, columns: list[Any]) -> torch.Tensor:
+    return torch.stack([ctx.decrypt(col, shape=(col.shape[0],)).to(torch.float64) for col in columns], dim=1)
+
+
+def _baseline_forward_no_dhp(attn: Any, x_columns: list[Any], seq_len: int, use_rihp: bool) -> list[Any]:
+    import cukks.batching as batching_module
+
+    if attn.q_weight is not None:
+        q_cols = attn._pcmm(x_columns, attn.q_weight, attn.q_bias)
+        k_cols = attn._pcmm(x_columns, attn.k_weight, attn.k_bias)
+        v_cols = attn._pcmm(x_columns, attn.v_weight, attn.v_bias)
+    else:
+        q_cols = list(x_columns)
+        k_cols = list(x_columns)
+        v_cols = list(x_columns)
+
+    rihp = batching_module.RIHPacker(seq_len) if use_rihp and seq_len % 2 == 0 else None
+    out_cols = []
+    for head_idx in range(attn.num_heads):
+        start = head_idx * attn.head_dim
+        end = start + attn.head_dim
+        out_cols.extend(attn._head_attention_from_columns(q_cols[start:end], k_cols[start:end], v_cols[start:end], seq_len, rihp))
+
+    if attn.out_weight is not None:
+        out_cols = attn._pcmm(out_cols, attn.out_weight, attn.out_bias)
+    return out_cols
+
+
+def test_pcmm_matches_torch_matmul(monkeypatch: pytest.MonkeyPatch):
+    from cukks.nn import EncryptedApproxAttention
+
+    torch.manual_seed(0)
+    ctx = _mock_ctx(monkeypatch)
+    seq_len, d_in, d_out = 6, 4, 8
+
+    x_plain = torch.randn(seq_len, d_in, dtype=torch.float64) * 0.1
+    w = torch.randn(d_in, d_out, dtype=torch.float64) * 0.1
+    x_cols = _encrypt_columns(ctx, x_plain)
+
+    attn = EncryptedApproxAttention(embed_dim=d_out, num_heads=2, normalization_mode="power_softmax")
+    y_cols = attn._pcmm(x_cols, w)
+    y_plain = _decrypt_columns(ctx, y_cols)
+
+    expected = x_plain @ w
+    torch.testing.assert_close(y_plain, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_pcmm_with_bias(monkeypatch: pytest.MonkeyPatch):
+    from cukks.nn import EncryptedApproxAttention
+
+    torch.manual_seed(1)
+    ctx = _mock_ctx(monkeypatch)
+    seq_len, d_in, d_out = 6, 4, 8
+
+    x_plain = torch.randn(seq_len, d_in, dtype=torch.float64) * 0.1
+    w = torch.randn(d_in, d_out, dtype=torch.float64) * 0.1
+    b = torch.randn(d_out, dtype=torch.float64) * 0.05
+    x_cols = _encrypt_columns(ctx, x_plain)
+
+    attn = EncryptedApproxAttention(embed_dim=d_out, num_heads=2, normalization_mode="power_softmax")
+    y_cols = attn._pcmm(x_cols, w, b)
+    y_plain = _decrypt_columns(ctx, y_cols)
+
+    expected = x_plain @ w + b
+    torch.testing.assert_close(y_plain, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_forward_stip_columns_no_weights(monkeypatch: pytest.MonkeyPatch):
+    from cukks.nn import EncryptedApproxAttention
+
+    torch.manual_seed(2)
+    ctx = _mock_ctx(monkeypatch)
+    x_plain = torch.randn(4, 4, dtype=torch.float64) * 0.1
+    x_cols = _encrypt_columns(ctx, x_plain)
+
+    attn = EncryptedApproxAttention(embed_dim=4, num_heads=2, normalization_mode="power_softmax")
+    out_cols = attn.forward_stip_columns(x_cols, seq_len=4)
+    out_plain = _decrypt_columns(ctx, out_cols)
+
+    assert len(out_cols) == 4
+    assert torch.isfinite(out_plain).all()
+    assert out_plain.abs().max().item() < 10.0
+
+
+def test_forward_stip_columns_matches_list_attention(monkeypatch: pytest.MonkeyPatch):
+    from cukks.nn import EncryptedApproxAttention
+
+    torch.manual_seed(3)
+    ctx = _mock_ctx(monkeypatch)
+    seq_len, d_model = 4, 4
+    x_plain = torch.randn(seq_len, d_model, dtype=torch.float64) * 0.1
+
+    attn = EncryptedApproxAttention(embed_dim=d_model, num_heads=2, normalization_mode="power_softmax")
+    attn.q_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.k_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.v_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.out_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.q_bias = torch.randn(d_model, dtype=torch.float64) * 0.01
+    attn.k_bias = torch.randn(d_model, dtype=torch.float64) * 0.01
+    attn.v_bias = torch.randn(d_model, dtype=torch.float64) * 0.01
+    attn.out_bias = torch.randn(d_model, dtype=torch.float64) * 0.01
+
+    x_cols = _encrypt_columns(ctx, x_plain)
+    out_cols = attn.forward_stip_columns(x_cols, seq_len=seq_len)
+    col_plain = _decrypt_columns(ctx, out_cols)
+
+    tokens = [ctx.encrypt(x_plain[token]) for token in range(seq_len)]
+    list_out = attn.forward_attention(tokens, tokens, tokens)
+    assert isinstance(list_out, list)
+    list_plain = torch.stack([ctx.decrypt(token).to(torch.float64) for token in list_out])
+
+    torch.testing.assert_close(col_plain, list_plain, rtol=5e-2, atol=5e-3)
+
+
+def test_rihp_used_when_seq_len_even(monkeypatch: pytest.MonkeyPatch):
+    from cukks.nn import EncryptedApproxAttention
+
+    torch.manual_seed(4)
+    ctx = _mock_ctx(monkeypatch)
+    seq_len, d_model = 4, 4
+    x_plain = torch.randn(seq_len, d_model, dtype=torch.float64) * 0.1
+    x_cols = _encrypt_columns(ctx, x_plain)
+
+    attn = EncryptedApproxAttention(embed_dim=d_model, num_heads=1, normalization_mode="power_softmax")
+    attn.q_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.k_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.v_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.out_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+
+    out_cols = attn.forward_stip_columns(x_cols, seq_len=seq_len)
+    baseline_cols = _baseline_forward_no_dhp(attn, x_cols, seq_len=seq_len, use_rihp=False)
+
+    out_plain = _decrypt_columns(ctx, out_cols)
+    baseline_plain = _decrypt_columns(ctx, baseline_cols)
+    torch.testing.assert_close(out_plain, baseline_plain, rtol=1e-4, atol=1e-4)
+
+
+def test_dhp_projection_used_when_heads_even(monkeypatch: pytest.MonkeyPatch):
+    from cukks.nn import EncryptedApproxAttention
+
+    torch.manual_seed(5)
+    ctx = _mock_ctx(monkeypatch)
+    seq_len, d_model = 4, 4
+    x_plain = torch.randn(seq_len, d_model, dtype=torch.float64) * 0.1
+    x_cols = _encrypt_columns(ctx, x_plain)
+
+    attn = EncryptedApproxAttention(embed_dim=d_model, num_heads=2, normalization_mode="power_softmax")
+    attn.q_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.k_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.v_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.out_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+
+    out_cols = attn.forward_stip_columns(x_cols, seq_len=seq_len)
+    baseline_cols = _baseline_forward_no_dhp(attn, x_cols, seq_len=seq_len, use_rihp=True)
+
+    out_plain = _decrypt_columns(ctx, out_cols)
+    baseline_plain = _decrypt_columns(ctx, baseline_cols)
+    torch.testing.assert_close(out_plain, baseline_plain, rtol=1e-4, atol=1e-4)
+
+
+def test_forward_stip_columns_odd_seq_len(monkeypatch: pytest.MonkeyPatch):
+    from cukks.nn import EncryptedApproxAttention
+
+    torch.manual_seed(6)
+    ctx = _mock_ctx(monkeypatch)
+    seq_len, d_model = 3, 4
+    x_plain = torch.randn(seq_len, d_model, dtype=torch.float64) * 0.1
+    x_cols = _encrypt_columns(ctx, x_plain)
+
+    attn = EncryptedApproxAttention(embed_dim=d_model, num_heads=1, normalization_mode="power_softmax")
+    attn.q_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.k_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.v_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+    attn.out_weight = torch.randn(d_model, d_model, dtype=torch.float64) * 0.1
+
+    out_cols = attn.forward_stip_columns(x_cols, seq_len=seq_len)
+    baseline_cols = _baseline_forward_no_dhp(attn, x_cols, seq_len=seq_len, use_rihp=False)
+
+    out_plain = _decrypt_columns(ctx, out_cols)
+    baseline_plain = _decrypt_columns(ctx, baseline_cols)
+    torch.testing.assert_close(out_plain, baseline_plain, rtol=1e-4, atol=1e-4)


### PR DESCRIPTION
## Summary

- Add column-wise attention path alongside the existing row-packed path, enabling optimal packing strategy selection per model architecture
- Implement three ciphertext packing algorithms that exploit complex CKKS slots to halve rotation counts and process two attention heads simultaneously
- Add inverse-free LayerNorm with automatic eligibility detection via `torch.fx`, reducing LN depth from 18 to 5 multiplicative levels

## Changes

### Packing Algorithms (`cukks/batching/`)
- **RIHPacker** (`rihp.py`): Real-imaginary hybrid packing — packs 2 diagonals per ciphertext via complex slots, halving column-column matrix multiplication cost
- **DHPacker** (`dhp.py`): Dual-head packing — processes adjacent attention head pairs simultaneously in complex slots
- **AMCPacker** (`amcp.py`): Adaptive multi-column packing — packs k feature columns per ciphertext with iterative group-wise rotation
- **PackingLayout** (`layout.py`): Metadata container for sequence packing configuration

### Inverse-Free LayerNorm (`cukks/nn/inverse_free_layernorm.py`, `cukks/analysis/`)
- `EncryptedInverseFreeLayerNorm`: Taylor-sqrt based LN consuming 5 levels (vs 18 for standard)
- Sigma propagation chain: LN stores `_sigma_factor` on output tensor, Linear layer detects it for bias scaling, next StandardLN clears it
- `inverse_free_detect.py`: `torch.fx` graph tracing to auto-detect eligible LayerNorms (requires homogeneous activation path: ReLU/Dropout/Identity only)

### Column-Wise Attention (`cukks/nn/attention.py`)
- `forward_stip_columns()`: Column-wise QK^T with halved rotations, softmax, and value weighting
- `forward_stip_columns_dhp()`: Dual-head variant processing 2 heads at once
- `_pcmm()`: Packed-column matrix multiplication helper
- `_head_attention_from_columns()`: Single-head attention from column vectors

### Complex-Slot Backend (`cukks/tensor.py`, `tests/mocks/mock_backend.py`)
- `mul_by_i()`, `extract_real()`, `extract_imag()`, `conjugate()` on EncryptedTensor
- Mock backend upgraded to `torch.complex128` for testing

### Converter & Context (`cukks/converter.py`, `cukks/context.py`)
- Path tracking in converter for LN eligibility analysis
- `TokenBlockPacker` and `PackingLayout` integration in context

### Documentation (`docs/stip-attention.md`)
- Packing strategy comparison (row vs column)
- Algorithm descriptions with formulas
- Practical attention layer limits with precision analysis
- Configuration and depth budget guide

## Testing

- [x] Tests pass (`pytest tests/ -v`) — **531 tests passing, 0 failures**
- 6 new test files with 85+ tests:
  - `test_rihp.py` (4 tests)
  - `test_amcp.py` (15 tests)
  - `test_dhp.py` (7 tests)
  - `test_inverse_free_layernorm.py` (33 tests)
  - `test_stip_attention.py` (19 tests)
  - `test_stip_wiring.py` (7 tests)

### Practical layer limits (cosine similarity > 0.99)

| Configuration | LayerNorm | Practical Layers |
|---|---|---|
| ReLU deg-4 | Inverse-Free (auto) | 2-3 |
| ReLU deg-8 | Inverse-Free (auto) | 8-10 |
| GELU deg-4 | Standard (auto) | 12+ |
| GELU deg-8 | Standard (auto) | 20+ |

## Related Issues

Closes #2 — Adds honest multi-token attention infrastructure with column-wise packing, complex-slot operations, and three packing algorithms. End-to-end bridge wiring and `encrypt_sequence_columns` API are tracked as follow-up.

Relates to #4 — Inverse-free LayerNorm avoids `crypto_inv_sqrt` entirely (uses Taylor-sqrt instead), providing a non-bootstrap LN path for models with homogeneous activations.
