### PR TITLE
perf: clean up shared benchmark helpers and test fixtures

### DIFF
--- a/experiments/_bench_bdlr_worker.py
+++ b/experiments/_bench_bdlr_worker.py
@@ -13,27 +13,8 @@ import torch.nn as nn
 import numpy as np
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from cukks.nn.block_diagonal import BlockDiagonalLinear
 from cukks.nn.block_diagonal_low_rank import BlockDiagLowRankLinear
-
-
-class SquareActivation(nn.Module):
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return x * x
-
-
-class BlockDiagMNIST(nn.Module):
-    def __init__(self, hidden: int, block_size: int) -> None:
-        super().__init__()
-        self.fc1 = nn.Linear(784, hidden)
-        self.act1 = SquareActivation()
-        self.fc2 = BlockDiagonalLinear(hidden, hidden, block_size=block_size)
-        self.act2 = SquareActivation()
-        self.fc3 = nn.Linear(hidden, 10)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = x.view(x.size(0), -1)
-        return self.fc3(self.act2(self.fc2(self.act1(self.fc1(x)))))
+from experiments._block_diag_bench_common import BlockDiagMNIST, SquareActivation
 
 
 class ConvertibleModel(nn.Module):

--- a/experiments/_bench_worker.py
+++ b/experiments/_bench_worker.py
@@ -17,85 +17,12 @@ import torch.nn as nn
 import numpy as np
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from cukks.nn.block_diagonal import BlockDiagonalLinear
-
-
-class SquareActivation(nn.Module):
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return x * x
-
-
-class BlockDiagMNIST(nn.Module):
-    """Training model with x² activations."""
-
-    def __init__(self, hidden: int, block_size: int) -> None:
-        super().__init__()
-        self.fc1 = nn.Linear(784, hidden)
-        self.act1 = SquareActivation()
-        self.fc2 = BlockDiagonalLinear(hidden, hidden, block_size=block_size)
-        self.act2 = SquareActivation()
-        self.fc3 = nn.Linear(hidden, 10)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = x.view(x.size(0), -1)
-        x = self.act1(self.fc1(x))
-        x = self.act2(self.fc2(x))
-        return self.fc3(x)
-
-
-class BlockDiagMNISTConvertible(nn.Module):
-    """Same architecture but with nn.ReLU so the converter can handle it."""
-
-    def __init__(self, hidden: int, block_size: int) -> None:
-        super().__init__()
-        self.fc1 = nn.Linear(784, hidden)
-        self.act1 = nn.ReLU()
-        self.fc2 = BlockDiagonalLinear(hidden, hidden, block_size=block_size)
-        self.act2 = nn.ReLU()
-        self.fc3 = nn.Linear(hidden, 10)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = x.view(x.size(0), -1)
-        x = self.act1(self.fc1(x))
-        x = self.act2(self.fc2(x))
-        return self.fc3(x)
-
-
-def count_nonzero_diagonals(model: BlockDiagMNIST) -> int:
-    dense_w = model.fc2.to_dense_weight().detach()
-    n = dense_w.shape[1]
-    count = 0
-    for d in range(n):
-        diag_vals = torch.tensor([dense_w[i, (i + d) % n].item() for i in range(dense_w.shape[0])])
-        if diag_vals.abs().max() > 0:
-            count += 1
-    return count
-
-
-def estimate_bsgs_rotations(in_features: int, nonzero_diags: int) -> dict:
-    n1 = math.ceil(math.sqrt(in_features))
-    n2 = math.ceil(in_features / n1)
-    baby_step_rots = n1 - 1
-    nonempty_giant_steps = 0
-    for k in range(n2):
-        giant_step = k * n1
-        has_nonzero = False
-        for j in range(n1):
-            d = giant_step + j
-            if d >= in_features:
-                break
-            if d < nonzero_diags or (in_features - d) <= nonzero_diags:
-                has_nonzero = True
-                break
-        if has_nonzero:
-            nonempty_giant_steps += 1
-    giant_step_rots = max(0, nonempty_giant_steps - 1)
-    return {
-        "total_rotations": baby_step_rots + giant_step_rots,
-        "total_evalmults": nonzero_diags,
-        "nonzero_diagonals": nonzero_diags,
-        "dense_diagonals": in_features,
-    }
+from experiments._block_diag_bench_common import (
+    BlockDiagMNIST,
+    BlockDiagMNISTConvertible,
+    count_nonzero_diagonals,
+    estimate_bsgs_rotations,
+)
 
 
 def main():
@@ -124,7 +51,7 @@ def main():
     model.load_state_dict(ckpt["model_state_dict"])
     model.eval()
 
-    nz_diags = count_nonzero_diagonals(model)
+    nz_diags = count_nonzero_diagonals(model.fc2)
     rot_stats = estimate_bsgs_rotations(args.hidden, nz_diags)
 
     conv_model = BlockDiagMNISTConvertible(ckpt["hidden"], ckpt["block_size"])

--- a/experiments/_block_diag_bench_common.py
+++ b/experiments/_block_diag_bench_common.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import json
+import math
+import os
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from cukks.nn.block_diagonal import BlockDiagonalLinear
+
+
+class SquareActivation(nn.Module):
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x * x
+
+
+class BlockDiagMNIST(nn.Module):
+    def __init__(self, hidden: int, block_size: int) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(784, hidden)
+        self.act1 = SquareActivation()
+        self.fc2 = BlockDiagonalLinear(hidden, hidden, block_size=block_size)
+        self.act2 = SquareActivation()
+        self.fc3 = nn.Linear(hidden, 10)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x.view(x.size(0), -1)
+        x = self.act1(self.fc1(x))
+        x = self.act2(self.fc2(x))
+        return self.fc3(x)
+
+
+class BlockDiagMNISTConvertible(nn.Module):
+    def __init__(self, hidden: int, block_size: int) -> None:
+        super().__init__()
+        self.fc1 = nn.Linear(784, hidden)
+        self.act1 = nn.ReLU()
+        self.fc2 = BlockDiagonalLinear(hidden, hidden, block_size=block_size)
+        self.act2 = nn.ReLU()
+        self.fc3 = nn.Linear(hidden, 10)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        x = x.view(x.size(0), -1)
+        x = self.act1(self.fc1(x))
+        x = self.act2(self.fc2(x))
+        return self.fc3(x)
+
+
+def count_nonzero_diagonals(layer: BlockDiagonalLinear) -> int:
+    dense_w = layer.to_dense_weight().detach()
+    rows = torch.arange(dense_w.shape[0])
+    count = 0
+    for diagonal_idx in range(dense_w.shape[1]):
+        diagonal = dense_w[rows, (rows + diagonal_idx) % dense_w.shape[1]]
+        if diagonal.abs().max() > 0:
+            count += 1
+    return count
+
+
+def estimate_bsgs_rotations(in_features: int, nonzero_diags: int) -> dict[str, int]:
+    n1 = math.ceil(math.sqrt(in_features))
+    n2 = math.ceil(in_features / n1)
+    baby_step_rots = n1 - 1
+    nonempty_giant_steps = 0
+
+    for giant_step_index in range(n2):
+        giant_step = giant_step_index * n1
+        has_nonzero = False
+        for baby_step_index in range(n1):
+            diagonal_idx = giant_step + baby_step_index
+            if diagonal_idx >= in_features:
+                break
+            if diagonal_idx < nonzero_diags or (in_features - diagonal_idx) <= nonzero_diags:
+                has_nonzero = True
+                break
+        if has_nonzero:
+            nonempty_giant_steps += 1
+
+    giant_step_rots = max(0, nonempty_giant_steps - 1)
+    return {
+        "total_rotations": baby_step_rots + giant_step_rots,
+        "total_evalmults": nonzero_diags,
+        "nonzero_diagonals": nonzero_diags,
+        "dense_diagonals": in_features,
+    }
+
+
+def default_worker_env() -> dict[str, str]:
+    env = os.environ.copy()
+    env.setdefault(
+        "LD_LIBRARY_PATH",
+        "/workspace/ckks-torch/openfhe-gpu-public/build/lib:"
+        "/workspace/ckks-torch/openfhe-gpu-public/build/_deps/rmm-build",
+    )
+    return env
+
+
+def parse_result_json(stdout: str) -> dict[str, Any] | None:
+    for line in stdout.strip().splitlines():
+        if line.startswith("RESULT_JSON:"):
+            return json.loads(line[len("RESULT_JSON:") :])
+    return None

--- a/experiments/bench_block_diagonal.py
+++ b/experiments/bench_block_diagonal.py
@@ -12,6 +12,8 @@ import json
 import os
 import subprocess
 
+from experiments._block_diag_bench_common import default_worker_env, parse_result_json
+
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 
 
@@ -30,15 +32,8 @@ def run_single_benchmark(
         "--num-samples", str(num_samples),
         "--device", device,
     ]
-    env = os.environ.copy()
-    env.setdefault(
-        "LD_LIBRARY_PATH",
-        "/workspace/ckks-torch/openfhe-gpu-public/build/lib:"
-        "/workspace/ckks-torch/openfhe-gpu-public/build/_deps/rmm-build",
-    )
-
     print(f"\n--- block_size={block_size} (subprocess) ---")
-    result = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=600)
+    result = subprocess.run(cmd, capture_output=True, text=True, env=default_worker_env(), timeout=600)
 
     if result.returncode != 0:
         print(f"STDERR:\n{result.stderr}")
@@ -47,9 +42,9 @@ def run_single_benchmark(
             "error": result.stderr.strip()[-500:],
         }
 
-    for line in result.stdout.strip().split("\n"):
-        if line.startswith("RESULT_JSON:"):
-            return json.loads(line[len("RESULT_JSON:"):])
+    parsed = parse_result_json(result.stdout)
+    if parsed is not None:
+        return parsed
 
     print(f"STDOUT:\n{result.stdout}")
     return {"block_size": block_size, "error": "no RESULT_JSON found in output"}

--- a/experiments/decompose_and_bench.py
+++ b/experiments/decompose_and_bench.py
@@ -13,35 +13,22 @@ import json
 import os
 import subprocess
 import sys
+from typing import cast
 
 import torch
 import torch.nn as nn
 from torchvision import datasets, transforms
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from cukks.nn.block_diagonal import BlockDiagonalLinear
 from cukks.nn.block_diagonal_low_rank import BlockDiagLowRankLinear
+from experiments._block_diag_bench_common import (
+    BlockDiagMNIST,
+    SquareActivation,
+    default_worker_env,
+    parse_result_json,
+)
 
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-
-
-class SquareActivation(nn.Module):
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return x * x
-
-
-class BlockDiagMNIST(nn.Module):
-    def __init__(self, hidden: int, block_size: int) -> None:
-        super().__init__()
-        self.fc1 = nn.Linear(784, hidden)
-        self.act1 = SquareActivation()
-        self.fc2 = BlockDiagonalLinear(hidden, hidden, block_size=block_size)
-        self.act2 = SquareActivation()
-        self.fc3 = nn.Linear(hidden, 10)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = x.view(x.size(0), -1)
-        return self.fc3(self.act2(self.fc2(self.act1(self.fc1(x)))))
 
 
 def load_dense_model(hidden: int) -> BlockDiagMNIST:
@@ -110,19 +97,13 @@ def run_encrypted_bench(hidden: int, block_size: int, rank: int, num_samples: in
         "--num-samples", str(num_samples),
         "--device", device,
     ]
-    env = os.environ.copy()
-    env.setdefault(
-        "LD_LIBRARY_PATH",
-        "/workspace/ckks-torch/openfhe-gpu-public/build/lib:"
-        "/workspace/ckks-torch/openfhe-gpu-public/build/_deps/rmm-build",
-    )
-    result = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=600)
+    result = subprocess.run(cmd, capture_output=True, text=True, env=default_worker_env(), timeout=600)
     if result.returncode != 0:
         print(f"  STDERR: {result.stderr[-300:]}", file=sys.stderr)
         return {"block_size": block_size, "rank": rank, "error": result.stderr.strip()[-200:]}
-    for line in result.stdout.strip().split("\n"):
-        if line.startswith("RESULT_JSON:"):
-            return json.loads(line[len("RESULT_JSON:"):])
+    parsed = parse_result_json(result.stdout)
+    if parsed is not None:
+        return parsed
     return {"block_size": block_size, "rank": rank, "error": "no RESULT_JSON"}
 
 
@@ -153,7 +134,7 @@ def main():
             continue
         print(f"block_size={bs}, rank={rank}:")
         decomposed = decompose_fc2(dense_model, bs, rank)
-        bd_lr = decomposed.fc2
+        bd_lr = cast(BlockDiagLowRankLinear, decomposed.fc2)
         acc = measure_accuracy(decomposed, args.data_dir)
         err = approx_error(dense_model, bd_lr)
         nz_diags = 2 * bs - 1 if bs < args.hidden else args.hidden

--- a/experiments/train_block_diagonal.py
+++ b/experiments/train_block_diagonal.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import math
 import os
 import sys
 import time
@@ -20,77 +19,11 @@ import torch.optim as optim
 from torchvision import datasets, transforms
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-from cukks.nn.block_diagonal import BlockDiagonalLinear
-
-
-class SquareActivation(nn.Module):
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return x * x
-
-
-class BlockDiagMNIST(nn.Module):
-    def __init__(self, hidden: int, block_size: int) -> None:
-        super().__init__()
-        self.fc1 = nn.Linear(784, hidden)
-        self.act1 = SquareActivation()
-        self.fc2 = BlockDiagonalLinear(hidden, hidden, block_size=block_size)
-        self.act2 = SquareActivation()
-        self.fc3 = nn.Linear(hidden, 10)
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = x.view(x.size(0), -1)
-        x = self.act1(self.fc1(x))
-        x = self.act2(self.fc2(x))
-        return self.fc3(x)
-
-
-def count_nonzero_diagonals(model: BlockDiagMNIST) -> int:
-    """Count non-zero diagonals of the block-diagonal layer's dense weight."""
-    dense_w = model.fc2.to_dense_weight().detach()
-    n = dense_w.shape[1]
-    count = 0
-    for d in range(n):
-        diag_vals = torch.tensor([dense_w[i, (i + d) % n].item() for i in range(dense_w.shape[0])])
-        if diag_vals.abs().max() > 0:
-            count += 1
-    return count
-
-
-def estimate_bsgs_rotations(in_features: int, nonzero_diags: int) -> dict:
-    n1 = math.ceil(math.sqrt(in_features))
-    n2 = math.ceil(in_features / n1)
-
-    baby_step_rots = n1 - 1
-
-    nonempty_giant_steps = 0
-    for k in range(n2):
-        giant_step = k * n1
-        has_nonzero = False
-        for j in range(n1):
-            d = giant_step + j
-            if d >= in_features:
-                break
-            diag_idx = d
-            if diag_idx < nonzero_diags or (in_features - diag_idx) <= nonzero_diags:
-                has_nonzero = True
-                break
-        if has_nonzero:
-            nonempty_giant_steps += 1
-
-    giant_step_rots = max(0, nonempty_giant_steps - 1)
-    total_rots = baby_step_rots + giant_step_rots
-    total_mults = nonzero_diags
-
-    return {
-        "n1": n1,
-        "n2": n2,
-        "baby_step_rotations": baby_step_rots,
-        "giant_step_rotations": giant_step_rots,
-        "total_rotations": total_rots,
-        "total_evalmults": total_mults,
-        "nonzero_diagonals": nonzero_diags,
-        "dense_diagonals": in_features,
-    }
+from experiments._block_diag_bench_common import (
+    BlockDiagMNIST,
+    count_nonzero_diagonals,
+    estimate_bsgs_rotations,
+)
 
 
 def train_one(
@@ -159,7 +92,7 @@ def train_one(
             total += target.size(0)
     final_acc = 100.0 * correct / total
 
-    nz_diags = count_nonzero_diagonals(model)
+    nz_diags = count_nonzero_diagonals(model.fc2)
     rot_stats = estimate_bsgs_rotations(hidden, nz_diags)
 
     result = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,12 +39,14 @@ def mock_enc_context():
 
 
 @pytest.fixture(scope="session")
-def use_mock_backend(monkeypatch):
-    from mocks import mock_backend
-    
+def use_mock_backend():
+    monkeypatch = pytest.MonkeyPatch()
+
     monkeypatch.setattr("cukks.context.CKKSConfig", MockCKKSConfig, raising=False)
     monkeypatch.setattr("cukks.context.CKKSContext", MockCKKSContext, raising=False)
     monkeypatch.setattr("cukks.tensor.EncryptedTensor", MockCKKSTensor, raising=False)
+    yield
+    monkeypatch.undo()
 
 
 # =============================================================================
@@ -63,6 +65,23 @@ def _has_real_backend():
 def _has_cuda():
     """Check if CUDA is available."""
     return torch.cuda.is_available()
+
+
+def _build_real_context(*, device: str, scale_bits: int, mult_depth: int, enable_gpu: bool):
+    from cukks import CKKSInferenceContext, InferenceConfig
+
+    config = InferenceConfig(
+        poly_mod_degree=32768,
+        scale_bits=scale_bits,
+        mult_depth=mult_depth,
+    )
+    return CKKSInferenceContext(
+        config=config,
+        device=device,
+        max_rotation_dim=2048,
+        use_bsgs=True,
+        enable_gpu=enable_gpu,
+    )
 
 
 # Skip markers
@@ -87,24 +106,8 @@ def real_context():
     """Real CKKS context on CPU."""
     if not _has_real_backend():
         pytest.skip("Real CKKS backend not available")
-    
-    from cukks import CKKSInferenceContext, InferenceConfig
-    
-    config = InferenceConfig(
-        poly_mod_degree=32768,
-        scale_bits=40,
-        mult_depth=6,
-    )
-    
-    ctx = CKKSInferenceContext(
-        config=config,
-        device="cpu",
-        max_rotation_dim=2048,
-        use_bsgs=True,
-        enable_gpu=False,  # Disable GPU for CPU-only tests
-    )
-    
-    return ctx
+
+    return _build_real_context(device="cpu", scale_bits=40, mult_depth=6, enable_gpu=False)
 
 
 @pytest.fixture(scope="session")
@@ -114,20 +117,5 @@ def gpu_context():
         pytest.skip("Real CKKS backend not available")
     if not _has_cuda():
         pytest.skip("CUDA not available")
-    
-    from cukks import CKKSInferenceContext, InferenceConfig
-    
-    config = InferenceConfig(
-        poly_mod_degree=32768,
-        scale_bits=50,
-        mult_depth=8,
-    )
-    
-    ctx = CKKSInferenceContext(
-        config=config,
-        device="cuda",
-        max_rotation_dim=2048,
-        use_bsgs=True,
-    )
-    
-    return ctx
+
+    return _build_real_context(device="cuda", scale_bits=50, mult_depth=8, enable_gpu=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def mock_enc_context():
     return EncryptedMockContext()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture
 def use_mock_backend():
     monkeypatch = pytest.MonkeyPatch()
 


### PR DESCRIPTION
## Summary
- extract shared block-diagonal experiment helpers so benchmark scripts reuse the same model, stats, env, and result parsing code
- simplify benchmark entrypoints by routing duplicated subprocess and helper logic through the shared module
- clean up shared test fixtures in `tests/conftest.py` by centralizing real-context construction and making mock backend patching teardown-safe

## Verification
- reviewed touched files directly
- ran `lsp_diagnostics` on all changed files with zero diagnostics
- did not run runtime tests, benchmarks, or builds because code execution is currently blocked while the GPU is reserved for other experiments