### PR TITLE
perf: cache activation coefficients and simplify converter traversal

### DIFF
--- a/cukks/converter.py
+++ b/cukks/converter.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import logging
 import warnings
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, Optional, Tuple, Type
+from typing import Any, Callable, Dict, List, Optional, Tuple, Type, cast
 
 import torch
 import torch.nn as nn
@@ -270,37 +270,55 @@ class ModelConverter:
         children: List[Tuple[str, nn.Module]],
     ) -> EncryptedSequential:
         """Convert a container module with children."""
+        return EncryptedSequential(self._convert_children(children))
+
+    def _maybe_convert_cnn_flatten_linear_pair(
+        self,
+        children: List[Tuple[str, nn.Module]],
+        index: int,
+        converted: "OrderedDict[str, EncryptedModule]",
+    ) -> bool:
+        if not (
+            self.options.optimize_cnn
+            and self._is_cnn_model
+            and isinstance(children[index][1], nn.Flatten)
+            and index + 1 < len(children)
+        ):
+            return False
+
+        name, child = children[index]
+        flatten = cast(nn.Flatten, child)
+        next_name, next_child = children[index + 1]
+        if not isinstance(next_child, nn.Linear):
+            return False
+
+        cnn_layout = self._compute_cnn_layout_from_linear(next_child)
+        if cnn_layout is None:
+            return False
+
+        converted[name] = EncryptedFlatten._with_absorbed_permutation(
+            flatten.start_dim,
+            flatten.end_dim,
+        )
+        converted[next_name] = EncryptedLinear.from_torch_cnn(next_child, cnn_layout)
+        return True
+
+    def _convert_children(
+        self,
+        children: List[Tuple[str, nn.Module]],
+    ) -> "OrderedDict[str, EncryptedModule]":
         converted = OrderedDict()
         skip_next = False
-        
+
         for i, (name, child) in enumerate(children):
             if skip_next:
                 skip_next = False
                 continue
-            
-            # CNN optimization: Flatten + Linear -> optimized Linear
-            if (self.options.optimize_cnn and 
-                self._is_cnn_model and
-                isinstance(child, nn.Flatten) and 
-                i + 1 < len(children)):
-                
-                _, next_child = children[i + 1]
-                if isinstance(next_child, nn.Linear):
-                    cnn_layout = self._compute_cnn_layout_from_linear(next_child)
-                    
-                    if cnn_layout is not None:
-                        converted[name] = EncryptedFlatten._with_absorbed_permutation(
-                            child.start_dim, 
-                            child.end_dim
-                        )
-                        next_name = children[i + 1][0]
-                        converted[next_name] = EncryptedLinear.from_torch_cnn(
-                            next_child, 
-                            cnn_layout
-                        )
-                        skip_next = True
-                        continue
-            
+
+            if self._maybe_convert_cnn_flatten_linear_pair(children, i, converted):
+                skip_next = True
+                continue
+
             try:
                 self._current_path.append(name)
                 converted[name] = self._convert_module(child)
@@ -311,7 +329,7 @@ class ModelConverter:
                 self._current_path.pop()
                 raise
             self._current_path.pop()
-        return EncryptedSequential(converted)
+        return converted
     
     def _convert_linear(self, module: nn.Linear) -> EncryptedModule:
         """Convert a Linear layer."""
@@ -339,53 +357,8 @@ class ModelConverter:
     
     def _convert_sequential(self, module: nn.Sequential) -> EncryptedSequential:
         """Convert a Sequential container with CNN optimizations."""
-        converted = OrderedDict()
         children = list(module.named_children())
-        skip_next = False
-        
-        for i, (name, child) in enumerate(children):
-            if skip_next:
-                skip_next = False
-                continue
-            
-            # CNN optimization: Flatten + Linear -> optimized Linear (absorb permutation)
-            if (self.options.optimize_cnn and 
-                self._is_cnn_model and
-                isinstance(child, nn.Flatten) and 
-                i + 1 < len(children)):
-                
-                _, next_child = children[i + 1]
-                if isinstance(next_child, nn.Linear):
-                    # Compute CNN layout from the Linear layer's input size
-                    cnn_layout = self._compute_cnn_layout_from_linear(next_child)
-                    
-                    if cnn_layout is not None:
-                        # Create Flatten with internal flag (no-op)
-                        converted[name] = EncryptedFlatten._with_absorbed_permutation(
-                            child.start_dim, 
-                            child.end_dim
-                        )
-                        # Create Linear with permuted weights
-                        next_name = children[i + 1][0]
-                        converted[next_name] = EncryptedLinear.from_torch_cnn(
-                            next_child, 
-                            cnn_layout
-                        )
-                        skip_next = True
-                        continue
-            
-            try:
-                self._current_path.append(name)
-                converted[name] = self._convert_module(child)
-            except NotImplementedError:
-                if isinstance(child, nn.Identity):
-                    self._current_path.pop()
-                    continue
-                self._current_path.pop()
-                raise
-            self._current_path.pop()
-                
-        return EncryptedSequential(converted)
+        return EncryptedSequential(self._convert_children(children))
     
     def _compute_cnn_layout_from_linear(self, linear: nn.Linear) -> Optional[Dict]:
         """Compute the CNN layout from Linear layer's input features.

--- a/cukks/converter.py
+++ b/cukks/converter.py
@@ -319,16 +319,15 @@ class ModelConverter:
                 skip_next = True
                 continue
 
+            self._current_path.append(name)
             try:
-                self._current_path.append(name)
                 converted[name] = self._convert_module(child)
             except NotImplementedError:
                 if isinstance(child, nn.Identity):
-                    self._current_path.pop()
                     continue
-                self._current_path.pop()
                 raise
-            self._current_path.pop()
+            finally:
+                self._current_path.pop()
         return converted
     
     def _convert_linear(self, module: nn.Linear) -> EncryptedModule:

--- a/cukks/nn/activations.py
+++ b/cukks/nn/activations.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 # =============================================================================
 
 @functools.lru_cache(maxsize=32)
-def _chebyshev_relu_coeffs(degree: int = 7, domain: tuple = (-1, 1)) -> List[float]:
+def _chebyshev_relu_coeffs(degree: int = 7, domain: tuple = (-1, 1)) -> tuple[float, ...]:
     """Compute power-basis polynomial coefficients for ReLU approximation.
     
     Uses least-squares fitting on uniform samples, then converts to power basis.
@@ -36,13 +36,13 @@ def _chebyshev_relu_coeffs(degree: int = 7, domain: tuple = (-1, 1)) -> List[flo
         power_coeffs = np.polynomial.chebyshev.cheb2poly(cheb_coeffs)
         while len(power_coeffs) > 1 and abs(power_coeffs[-1]) < 1e-12:
             power_coeffs = power_coeffs[:-1]
-        return power_coeffs.tolist()
+        return tuple(float(value) for value in power_coeffs.tolist())
     except ImportError:
-        return [0.0, 0.5, 0.25]
+        return (0.0, 0.5, 0.25)
 
 
 @functools.lru_cache(maxsize=32)
-def _minimax_relu_coeffs(degree: int = 4, domain: tuple = (-4, 4)) -> List[float]:
+def _minimax_relu_coeffs(degree: int = 4, domain: tuple = (-4, 4)) -> tuple[float, ...]:
     """Minimax polynomial approximation for ReLU.
     
     Pre-computed coefficients are available for [-1,1]. For other domains,
@@ -51,9 +51,9 @@ def _minimax_relu_coeffs(degree: int = 4, domain: tuple = (-4, 4)) -> List[float
     a, b = domain
     if a == -1 and b == 1:
         coefficients = {
-            2: [0.375, 0.5, 0.125],
-            3: [0.3125, 0.5, 0.25, -0.0625],
-            4: [0.2734375, 0.5, 0.3125, -0.125, 0.0234375],
+            2: (0.375, 0.5, 0.125),
+            3: (0.3125, 0.5, 0.25, -0.0625),
+            4: (0.2734375, 0.5, 0.3125, -0.125, 0.0234375),
         }
         if degree in coefficients:
             return coefficients[degree]
@@ -61,7 +61,7 @@ def _minimax_relu_coeffs(degree: int = 4, domain: tuple = (-4, 4)) -> List[float
 
 
 @functools.lru_cache(maxsize=32)
-def _gelu_poly_coeffs(degree: int = 4) -> List[float]:
+def _gelu_poly_coeffs(degree: int = 4) -> tuple[float, ...]:
     """Polynomial approximation for GELU: x * Phi(x).
     
     Uses Chebyshev approximation for GELU on [-1, 1].
@@ -80,15 +80,15 @@ def _gelu_poly_coeffs(degree: int = 4) -> List[float]:
         cheb_coeffs = chebfit(x, y, degree)
         # Convert from Chebyshev basis to power basis for poly_eval
         power_coeffs = cheb2poly(cheb_coeffs)
-        return power_coeffs.tolist()
+        return tuple(float(value) for value in power_coeffs.tolist())
     except ImportError:
         # Fallback: hardcoded degree-4 power-basis coefficients
         # GELU(x) ≈ 0.5*x*(1 + tanh(sqrt(2/π)*(x + 0.044715*x^3)))
-        return [0.0, 0.5, 0.0, 0.0398942, 0.0]
+        return (0.0, 0.5, 0.0, 0.0398942, 0.0)
 
 
 @functools.lru_cache(maxsize=32)
-def _sigmoid_poly_coeffs(degree: int = 4) -> List[float]:
+def _sigmoid_poly_coeffs(degree: int = 4) -> tuple[float, ...]:
     """Polynomial approximation for sigmoid on [-4, 4].
     
     sigmoid(x) = 1 / (1 + exp(-x))
@@ -105,13 +105,13 @@ def _sigmoid_poly_coeffs(degree: int = 4) -> List[float]:
         y = sigmoid(x)
         cheb_coeffs = chebfit(x, y, degree)
         power_coeffs = cheb2poly(cheb_coeffs)
-        return power_coeffs.tolist()
+        return tuple(float(value) for value in power_coeffs.tolist())
     except ImportError:
-        return [0.5, 0.25, 0.0, -0.0208333, 0.0]
+        return (0.5, 0.25, 0.0, -0.0208333, 0.0)
 
 
 @functools.lru_cache(maxsize=32)
-def _tanh_poly_coeffs(degree: int = 5) -> List[float]:
+def _tanh_poly_coeffs(degree: int = 5) -> tuple[float, ...]:
     """Polynomial approximation for tanh.
     
     Returns power-basis coefficients [a0, a1, a2, ...] for poly_eval.
@@ -125,13 +125,13 @@ def _tanh_poly_coeffs(degree: int = 5) -> List[float]:
         cheb_coeffs = chebfit(x, y, degree)
         # Convert from Chebyshev basis to power basis for poly_eval
         power_coeffs = cheb2poly(cheb_coeffs)
-        return power_coeffs.tolist()
+        return tuple(float(value) for value in power_coeffs.tolist())
     except ImportError:
-        return [0.0, 1.0, 0.0, -0.333333, 0.0, 0.133333]
+        return (0.0, 1.0, 0.0, -0.333333, 0.0, 0.133333)
 
 
 @functools.lru_cache(maxsize=32)
-def _silu_poly_coeffs(degree: int = 4) -> List[float]:
+def _silu_poly_coeffs(degree: int = 4) -> tuple[float, ...]:
     """Polynomial approximation for SiLU (x * sigmoid(x)).
     
     Returns power-basis coefficients [a0, a1, a2, ...] for poly_eval.
@@ -147,9 +147,9 @@ def _silu_poly_coeffs(degree: int = 4) -> List[float]:
         y = silu(x)
         cheb_coeffs = chebfit(x, y, degree)
         power_coeffs = cheb2poly(cheb_coeffs)
-        return power_coeffs.tolist()
+        return tuple(float(value) for value in power_coeffs.tolist())
     except ImportError:
-        return [0.0, 0.5, 0.25, 0.0, -0.0104167]
+        return (0.0, 0.5, 0.25, 0.0, -0.0104167)
 
 
 # =============================================================================
@@ -196,9 +196,9 @@ class EncryptedReLU(EncryptedModule):
         self.method = method
         
         if method == "minimax":
-            self.coeffs = _minimax_relu_coeffs(degree, domain)
+            self.coeffs = list(_minimax_relu_coeffs(degree, domain))
         else:
-            self.coeffs = _chebyshev_relu_coeffs(degree, domain)
+            self.coeffs = list(_chebyshev_relu_coeffs(degree, domain))
     
     def forward(self, x: "EncryptedTensor") -> "EncryptedTensor":
         result = x.poly_eval(self.coeffs)
@@ -224,7 +224,7 @@ class EncryptedGELU(EncryptedModule):
     def __init__(self, degree: int = 4) -> None:
         super().__init__()
         self.degree = degree
-        self.coeffs = _gelu_poly_coeffs(degree)
+        self.coeffs = list(_gelu_poly_coeffs(degree))
     
     def forward(self, x: "EncryptedTensor") -> "EncryptedTensor":
         result = x.poly_eval(self.coeffs)
@@ -250,7 +250,7 @@ class EncryptedSiLU(EncryptedModule):
     def __init__(self, degree: int = 4) -> None:
         super().__init__()
         self.degree = degree
-        self.coeffs = _silu_poly_coeffs(degree)
+        self.coeffs = list(_silu_poly_coeffs(degree))
     
     def forward(self, x: "EncryptedTensor") -> "EncryptedTensor":
         result = x.poly_eval(self.coeffs)
@@ -274,7 +274,7 @@ class EncryptedSigmoid(EncryptedModule):
     def __init__(self, degree: int = 4) -> None:
         super().__init__()
         self.degree = degree
-        self.coeffs = _sigmoid_poly_coeffs(degree)
+        self.coeffs = list(_sigmoid_poly_coeffs(degree))
     
     def forward(self, x: "EncryptedTensor") -> "EncryptedTensor":
         result = x.poly_eval(self.coeffs)
@@ -298,7 +298,7 @@ class EncryptedTanh(EncryptedModule):
     def __init__(self, degree: int = 5) -> None:
         super().__init__()
         self.degree = degree
-        self.coeffs = _tanh_poly_coeffs(degree)
+        self.coeffs = list(_tanh_poly_coeffs(degree))
     
     def forward(self, x: "EncryptedTensor") -> "EncryptedTensor":
         result = x.poly_eval(self.coeffs)

--- a/cukks/nn/activations.py
+++ b/cukks/nn/activations.py
@@ -8,6 +8,7 @@ various approximation methods.
 
 from __future__ import annotations
 
+import functools
 from typing import TYPE_CHECKING, Any, List, Sequence
 
 from .module import EncryptedModule
@@ -20,6 +21,7 @@ if TYPE_CHECKING:
 # Polynomial Approximation Coefficients
 # =============================================================================
 
+@functools.lru_cache(maxsize=32)
 def _chebyshev_relu_coeffs(degree: int = 7, domain: tuple = (-1, 1)) -> List[float]:
     """Compute power-basis polynomial coefficients for ReLU approximation.
     
@@ -39,6 +41,7 @@ def _chebyshev_relu_coeffs(degree: int = 7, domain: tuple = (-1, 1)) -> List[flo
         return [0.0, 0.5, 0.25]
 
 
+@functools.lru_cache(maxsize=32)
 def _minimax_relu_coeffs(degree: int = 4, domain: tuple = (-4, 4)) -> List[float]:
     """Minimax polynomial approximation for ReLU.
     
@@ -57,6 +60,7 @@ def _minimax_relu_coeffs(degree: int = 4, domain: tuple = (-4, 4)) -> List[float
     return _chebyshev_relu_coeffs(degree, domain)
 
 
+@functools.lru_cache(maxsize=32)
 def _gelu_poly_coeffs(degree: int = 4) -> List[float]:
     """Polynomial approximation for GELU: x * Phi(x).
     
@@ -83,6 +87,7 @@ def _gelu_poly_coeffs(degree: int = 4) -> List[float]:
         return [0.0, 0.5, 0.0, 0.0398942, 0.0]
 
 
+@functools.lru_cache(maxsize=32)
 def _sigmoid_poly_coeffs(degree: int = 4) -> List[float]:
     """Polynomial approximation for sigmoid on [-4, 4].
     
@@ -105,6 +110,7 @@ def _sigmoid_poly_coeffs(degree: int = 4) -> List[float]:
         return [0.5, 0.25, 0.0, -0.0208333, 0.0]
 
 
+@functools.lru_cache(maxsize=32)
 def _tanh_poly_coeffs(degree: int = 5) -> List[float]:
     """Polynomial approximation for tanh.
     
@@ -124,6 +130,7 @@ def _tanh_poly_coeffs(degree: int = 5) -> List[float]:
         return [0.0, 1.0, 0.0, -0.333333, 0.0, 0.133333]
 
 
+@functools.lru_cache(maxsize=32)
 def _silu_poly_coeffs(degree: int = 4) -> List[float]:
     """Polynomial approximation for SiLU (x * sigmoid(x)).
     


### PR DESCRIPTION
## Summary
- cache activation polynomial coefficient generation so repeated encrypted module construction reuses the same approximation results
- make cached activation coefficients immutable and copy them into module-local state to avoid cache poisoning
- deduplicate converter child traversal so container and sequential conversion share the same Flatten+Linear optimization and path handling logic

## Verification
- reviewed touched files directly
- ran `lsp_diagnostics` on `cukks/nn/activations.py` and `cukks/converter.py` with zero diagnostics
- did not run runtime tests, builds, or conversion flows because code execution is currently blocked while the GPU is reserved for other experiments