### PR TITLE
perf: cache reusable attention and convolution metadata

### DIFF
--- a/cukks/nn/attention.py
+++ b/cukks/nn/attention.py
@@ -8,6 +8,7 @@ All attention computations run in pure HE using cipher-cipher operations.
 
 from __future__ import annotations
 
+from collections import OrderedDict
 import functools
 import math
 from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
@@ -125,6 +126,10 @@ class EncryptedApproxAttention(EncryptedModule):
         self._exp_coeffs = _taylor_exp_coeffs(softmax_degree)
         self._gaussian_exp_coeffs = _gaussian_exp_coeffs(self._gaussian_domain, softmax_degree)
         self._reciprocal_degree = 15
+        self._packed_metadata_cache: OrderedDict[
+            tuple[int, int, int, int, int, int],
+            tuple[list[list[float]], list[list[float]], list[list[float]], tuple[int, ...], torch.Tensor],
+        ] = OrderedDict()
         
         # Projection weights (initialized as identity for now)
         # These can be set via from_torch or manually
@@ -178,7 +183,18 @@ class EncryptedApproxAttention(EncryptedModule):
         x: "EncryptedTensor",
         seq_len: int,
         embed_dim: int,
-    ) -> tuple[list[list[float]], list[list[float]], list[list[float]], set[int], torch.Tensor]:
+    ) -> tuple[list[list[float]], list[list[float]], list[list[float]], tuple[int, ...], torch.Tensor]:
+        batch_size = getattr(x, "_batch_size", None)
+        slots_per_sample = getattr(x, "_slots_per_sample", None)
+        if batch_size is None or slots_per_sample is None:
+            raise RuntimeError("Packed attention requires packed batch metadata")
+
+        cache_key = (x._cipher.size, batch_size, slots_per_sample, seq_len, embed_dim, self.num_heads)
+        cached = self._packed_metadata_cache.get(cache_key)
+        if cached is not None:
+            self._packed_metadata_cache.move_to_end(cache_key)
+            return cached
+
         query_masks = [self._packed_token_mask(x, token_index, seq_len) for token_index in range(seq_len)]
         power_outside_fills = [
             [-2.0 * (1.0 - value) for value in query_mask]
@@ -189,13 +205,17 @@ class EncryptedApproxAttention(EncryptedModule):
             [gaussian_distance_cap * (1.0 - value) for value in query_mask]
             for query_mask in query_masks
         ]
-        rotation_offsets = {
+        rotation_offsets = tuple(sorted({
             (key_index - query_index) * embed_dim
             for query_index in range(seq_len)
             for key_index in range(seq_len)
-        }
+        }))
         ones_block = torch.ones(embed_dim, embed_dim, dtype=torch.float64)
-        return query_masks, power_outside_fills, gaussian_outside_fills, rotation_offsets, ones_block
+        cached = (query_masks, power_outside_fills, gaussian_outside_fills, rotation_offsets, ones_block)
+        if len(self._packed_metadata_cache) >= 8:
+            self._packed_metadata_cache.popitem(last=False)
+        self._packed_metadata_cache[cache_key] = cached
+        return cached
 
     def _validate_stip_layout(self, x: "EncryptedTensor") -> tuple[int, int]:
         layout = getattr(x, "_packing_layout", None)

--- a/cukks/nn/conv.py
+++ b/cukks/nn/conv.py
@@ -88,6 +88,7 @@ class EncryptedConv2d(EncryptedModule):
         self._wm_bias_list: list | None = None
         self._wm_hash: int = 0
         self._wm_diag_nonzero: list | None = None
+        self._packed_compact_cache: dict[tuple[int, int, int], list[int]] = {}
         if hasattr(self, "weight_matrix"):
             self._ensure_weight_matrix_cache()
         
@@ -340,42 +341,36 @@ class EncryptedConv2d(EncryptedModule):
         total_in = num_patches * patch_features
 
         slot_count = x._cipher.size
-        W = self.weight_matrix.to(torch.float64)
         C = self.out_channels
-        K = patch_features
 
         x_flat = x.view(total_in)
-
-        nonzero_diags = set()
-        for p in range(num_patches):
-            for delta in range(-(C - 1), K):
-                d = (p * (K - C) + delta) % total_in
-                nonzero_diags.add(d)
+        diagonal_offsets = self._get_packed_compact_offsets(
+            num_patches,
+            patch_features,
+            slot_count,
+        )
+        W = self.weight_matrix.to(torch.float64)
 
         accumulator = None
 
-        for d in sorted(nonzero_diags):
+        for d in diagonal_offsets:
             diag_vals = torch.zeros(slot_count, dtype=torch.float64)
             has_nonzero = False
-
             for i in range(min(total_out, slot_count)):
                 row = i
                 col = (i + d) % total_in
-
                 row_patch = row // C
+                col_patch = col // patch_features
+                if row_patch != col_patch:
+                    continue
                 row_c = row % C
-                col_patch = col // K
-                col_k = col % K
-
-                if row_patch == col_patch:
-                    val = W[row_c, col_k].item()
-                    if abs(val) > 1e-30:
-                        diag_vals[i] = val
-                        has_nonzero = True
-
+                col_k = col % patch_features
+                val = W[row_c, col_k].item()
+                if abs(val) > 1e-30:
+                    diag_vals[i] = val
+                    has_nonzero = True
             if not has_nonzero:
                 continue
-
             rotated = x_flat.rotate(d) if d != 0 else x_flat
             term = rotated.mul(diag_vals.tolist())
             term = term.rescale()
@@ -412,6 +407,30 @@ class EncryptedConv2d(EncryptedModule):
             accumulator._batch_size = batch_size
             accumulator._slots_per_sample = (num_patches // batch_size) * self.out_channels
         return accumulator
+
+    def _get_packed_compact_offsets(
+        self,
+        num_patches: int,
+        patch_features: int,
+        slot_count: int,
+    ) -> list[int]:
+        cache_key = (num_patches, patch_features, slot_count)
+        cached = self._packed_compact_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        total_in = num_patches * patch_features
+        C = self.out_channels
+        K = patch_features
+
+        nonzero_diags = set()
+        for p in range(num_patches):
+            for delta in range(-(C - 1), K):
+                nonzero_diags.add((p * (K - C) + delta) % total_in)
+
+        cached = sorted(nonzero_diags)
+        self._packed_compact_cache[cache_key] = cached
+        return cached
 
     @staticmethod
     def unfold_input(


### PR DESCRIPTION
## Summary
- memoize packed attention metadata by structural layout so repeated packed self-attention calls reuse masks, fills, and rotation offsets
- add a bounded instance-local LRU for packed attention metadata to avoid unbounded cache growth
- cache compact convolution diagonal offsets so large packed convolution paths stop rebuilding the same structural offset set on every call

## Verification
- reviewed `cukks/nn/attention.py` and `cukks/nn/conv.py` directly
- ran `lsp_diagnostics` on both changed files with zero diagnostics
- ran full GPU integration test suite on RTX 5090 against real CKKS backend: 21 passed, 0 failed