### PR TITLE
perf: add -O3 and LTO build flags to CuKKSBackend.cmake

### DIFF
--- a/cmake/CuKKSBackend.cmake
+++ b/cmake/CuKKSBackend.cmake
@@ -22,6 +22,24 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # ------------------------------------------------------------------------------
+# Optimization Flags
+# NOTE: -march=native targets the build machine's CPU instruction set.
+#       For portable wheel distribution swap it for -march=x86-64-v3 (AVX2).
+# ------------------------------------------------------------------------------
+if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    add_compile_options(-O3 -march=native)
+endif()
+
+include(CheckIPOSupported)
+check_ipo_supported(RESULT _ipo_supported OUTPUT _ipo_output)
+if(_ipo_supported)
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
+    message(STATUS "IPO/LTO enabled")
+else()
+    message(STATUS "IPO/LTO not supported: ${_ipo_output}")
+endif()
+
+# ------------------------------------------------------------------------------
 # GPU Support
 # ------------------------------------------------------------------------------
 option(CUKKS_ENABLE_GPU "Enable GPU support" ON)

--- a/cmake/CuKKSBackend.cmake
+++ b/cmake/CuKKSBackend.cmake
@@ -23,11 +23,9 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # ------------------------------------------------------------------------------
 # Optimization Flags
-# NOTE: -march=native targets the build machine's CPU instruction set.
-#       For portable wheel distribution swap it for -march=x86-64-v3 (AVX2).
 # ------------------------------------------------------------------------------
 if(CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
-    add_compile_options(-O3 -march=native)
+    add_compile_options(-O3)
 endif()
 
 include(CheckIPOSupported)


### PR DESCRIPTION
## Summary

- Enable `-O3` compiler optimization across both C++ backend extension modules
- Enable Link-Time Optimization (LTO) via CMake's `CheckIPOSupported`, with graceful fallback if the toolchain does not support it

## Changes

- `cmake/CuKKSBackend.cmake`: added a new **Optimization Flags** section
  - `-O3` applied to all GNU/Clang builds (replaces the implicit `-O2` of Release mode)
  - `CMAKE_INTERPROCEDURAL_OPTIMIZATION` enabled when the toolchain supports IPO/LTO
  - `-march=native` was considered but excluded — it would bind the compiled `.so` to the build machine's CPU instruction set, breaking portability of distributed wheels on end-user machines with different microarchitectures

## Testing

- [ ] Tests pass (`pytest tests/ -v`)
- [ ] Build succeeds (if C++/CUDA changes)

## Related Issues

<!-- Closes # -->